### PR TITLE
Add iterkeys and itervalues methods to odict class.

### DIFF
--- a/netlib/odict.py
+++ b/netlib/odict.py
@@ -159,6 +159,18 @@ class ODict:
         self.lst = nlst
         return count
 
+    def iterkeys(self):
+        keys = []
+	for i in self.lst:
+            keys.append(i[0])
+        return keys
+
+    def itervalues(self):
+        values = []
+        for i in self.lst:
+            values.append(i[1])
+        return values
+
 
 class ODictCaseless(ODict):
     """


### PR DESCRIPTION
Aldo - 

I made some changes to the ODict class in netlib to add iterkeys() and itervalues() methods so that ODicts behave similarly to Python's native dictionaries.  That said, I didn't change ODict's **iter** method, so code such as "for i in anODict" returns a header, value list.

I don't know if these methods will of be of any help, but I wanted to assist.

Thanks,
Jason
