### PR TITLE
extensions aren't supported in v1, set to v3 (value=2) if using them.

### DIFF
--- a/netlib/certutils.py
+++ b/netlib/certutils.py
@@ -110,6 +110,7 @@ def dummy_cert(fp, ca, commonname, sans):
     cert.set_subject(req.get_subject())
     cert.set_serial_number(int(time.time()*10000))
     if ss:
+        cert.set_version(2)
         cert.add_extensions([OpenSSL.crypto.X509Extension("subjectAltName", True, ss)])
     cert.set_pubkey(req.get_pubkey())
     cert.sign(key, "sha1")


### PR DESCRIPTION
Generated dummy certificates are (technically) incorrect, even though many tools accept them, but e.g. Java will refuse to parse them. Extensions are supported in x509v3, so in case they are used, this will set the certificate version number appropriately.
