### PR TITLE
add test case for invalid characters in cert commonnames

### DIFF
--- a/test/test_certutils.py
+++ b/test/test_certutils.py
@@ -34,6 +34,7 @@ class TestCertStore:
             assert not c.get_cert("foo.com", [])
             assert c.get_cert("foo.com", [], ca)
             assert c.get_cert("foo.com", [], ca)
+            assert c.get_cert("*.foo.com", [], ca)
             c.cleanup()
 
     def test_check_domain(self):


### PR DESCRIPTION
Hey @cortesi,

while <code>check_domain</code> allows all plain-ASCII chars in the commonname, some operating systems or file systems (Windows/FAT) don't. This has the nasty side effect that wildcart certificates (<code>*.facebook.com, *.github.com</code>) break. I am using <code>.replace("*","")</code> as a nasty workaround, but you mentioned that you're looking for a more generic solution here. Let me know what you're thinking of and I'll give it a shot.

Cheers,
Max
