### PR TITLE
attempt to fix 'half-duplex' TCP close sequence

### DIFF
--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -230,11 +230,15 @@ class TCPClient:
             if self.ssl_established:
                 self.connection.shutdown()
             else:
-                self.connection.shutdown(socket.SHUT_RDWR)
-            self.connection.close()
+                self.connection.shutdown(socket.SHUT_WR)
+            #Section 4.2.2.13 of RFC 1122 tells us that a close() with any pending readable data could lead to an immediate RST being sent.
+            #http://ia600609.us.archive.org/22/items/TheUltimateSo_lingerPageOrWhyIsMyTcpNotReliable/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable.html
+            while self.connection.recv(4096):
+                pass
         except (socket.error, SSL.Error):
             # Socket probably already closed
             pass
+        self.connection.close()
 
 
 class BaseHandler:
@@ -328,10 +332,15 @@ class BaseHandler:
             if self.ssl_established:
                 self.connection.shutdown()
             else:
-                self.connection.shutdown(socket.SHUT_RDWR)
+                self.connection.shutdown(socket.SHUT_WR)
+            #Section 4.2.2.13 of RFC 1122 tells us that a close() with any pending readable data could lead to an immediate RST being sent.
+            #http://ia600609.us.archive.org/22/items/TheUltimateSo_lingerPageOrWhyIsMyTcpNotReliable/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable.html
+            while self.connection.recv(4096):
+                pass
         except (socket.error, SSL.Error):
             # Socket probably already closed
             pass
+
         self.connection.close()
 
 


### PR DESCRIPTION
A attempt to fix the socket bug I encountered on windows.

To quote RFC 1122: 4.2.2.13

> A host MAY implement a "half-duplex" TCP close sequence, so that an application that has called CLOSE cannot continue to read data from the connection. If such a host issues a CLOSE call **while received data is still pending in TCP**, or if new data is received after CLOSE is called, its TCP SHOULD send a RST to show that data was lost.

This looks like the bug we are observing. I implemented the solution proposed here:
http://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable

@cortesi, does this have any negative impact on OSX or Linux?
