### PR TITLE
adding cipher list selection option to BaseHandler

### DIFF
--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -266,7 +266,7 @@ class BaseHandler:
 
         self.clientcert = None
 
-    def convert_to_ssl(self, cert, key, method=SSLv23_METHOD, options=None, handle_sni=None, request_client_cert=False):
+    def convert_to_ssl(self, cert, key, method=SSLv23_METHOD, options=None, handle_sni=None, request_client_cert=False, cipher_list=None):
         """
             cert: A certutils.SSLCert object.
             method: One of SSLv2_METHOD, SSLv3_METHOD, SSLv23_METHOD, or TLSv1_METHOD
@@ -294,6 +294,8 @@ class BaseHandler:
         ctx = SSL.Context(method)
         if not options is None:
             ctx.set_options(options)
+        if cipher_list:
+            ctx.set_cipher_list(cipher_list)
         if handle_sni:
             # SNI callback happens during do_handshake()
             ctx.set_tlsext_servername_callback(handle_sni)

--- a/netlib/test.py
+++ b/netlib/test.py
@@ -66,7 +66,8 @@ class TServer(tcp.TCPServer):
                 method = method,
                 options = options,
                 handle_sni = getattr(h, "handle_sni", None),
-                request_client_cert = self.ssl["request_client_cert"]
+                request_client_cert = self.ssl["request_client_cert"],
+                cipher_list = self.ssl.get("cipher_list", None)
             )
         h.handle()
         h.finish()

--- a/test/test_tcp.py
+++ b/test/test_tcp.py
@@ -34,6 +34,15 @@ class CertHandler(tcp.BaseHandler):
         self.wfile.flush()
 
 
+class ClientCipherListHandler(tcp.BaseHandler):
+    sni = None
+
+    def handle(self):
+        print self.connection.get_cipher_list()
+        self.wfile.write("%s"%self.connection.get_cipher_list())
+        self.wfile.flush()
+
+
 class DisconnectHandler(tcp.BaseHandler):
     def handle(self):
         self.close()
@@ -178,6 +187,22 @@ class TestSNI(test.ServerTestBase):
         c.connect()
         c.convert_to_ssl(sni="foo.com")
         assert c.rfile.readline() == "foo.com"
+
+
+class TestClientCipherList(test.ServerTestBase):
+    handler = ClientCipherListHandler
+    ssl = dict(
+        cert = tutils.test_data.path("data/server.crt"),
+        key = tutils.test_data.path("data/server.key"),
+        request_client_cert = False,
+        v3_only = False,
+        cipher_list = 'RC4-SHA'
+    )
+    def test_echo(self):
+        c = tcp.TCPClient("127.0.0.1", self.port)
+        c.connect()
+        c.convert_to_ssl(sni="foo.com")
+        assert c.rfile.readline() == "['RC4-SHA']"
 
 
 class TestSSLDisconnect(test.ServerTestBase):


### PR DESCRIPTION
(partially) Reimplementing a feature that existed in mitmproxy 0.8. This change and a soon coming pull request to mitmproxy itself will allow the user to specify a desired cipher suite between the client and proxy. 
