### PR TITLE
refactor http.read_http_body

### DIFF
--- a/netlib/test.py
+++ b/netlib/test.py
@@ -18,7 +18,7 @@ class ServerTestBase:
     handler = None
     addr = ("localhost", 0)
     use_ipv6 = False
-    
+
     @classmethod
     def setupAll(cls):
         cls.q = Queue.Queue()

--- a/test/test_tcp.py
+++ b/test/test_tcp.py
@@ -133,7 +133,6 @@ class TestFinishFail(test.ServerTestBase):
         c.wfile.flush()
         c.rfile.read(4)
 
-
 class TestDisconnect(test.ServerTestBase):
     handler = EchoHandler
     def test_echo(self):


### PR DESCRIPTION
This PR refactors read_http_body to work according to the [spec](http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-16#section-3.3). This has been neccessary as the current version omits response bodies if no content-length header is set.

In particular, <code>http://spiegel.ivwbox.de/2004/01/survey.js</code> did not work as of 0.9.2.

Theses changes affect pathod and mitmproxy as well.
