### PR TITLE
Change error into awesome user-friendlyness

### DIFF
--- a/netlib/odict.py
+++ b/netlib/odict.py
@@ -60,9 +60,8 @@ class ODict:
             key, they are cleared.
         """
         if isinstance(valuelist, basestring):
-            # convert the string into a single element list.
-            valuelist = [valuelist]
-            
+            raise ValueError("Expected list instead of string. E.g. odict['elem'] = ['string1', 'string2']")
+
         new = self._filter_lst(k, self.lst)
         for i in valuelist:
             new.append([k, i])


### PR DESCRIPTION
Hi there,

I was getting a very weird error "ODict valuelist should be lists", when attempting to add a header.

My code was as followed (using libmproxy):

```
msg.headers["API-Key"] = new_headers["API-Key"]                                                                                                                                                                              
msg.headers["API-Sign"] = new_headers["API-Sign"]
```

In the end, that was because **setitem** on odict expected lists instead of strings. In order to cater to that, you guys might enjoy the patch I attach, for it converts strings automatically into lists!.

I think it should work, but I haven't tested it :$

It'd allow me to have the above code, instead of this one below:

```
msg.headers["API-Key"] = [new_headers["API-Key"]]                                                                                                                                                                               
msg.headers["API-Sign"] = [new_headers["API-Sign"]]
```
