### PR TITLE
More accurate host, port parsing

### DIFF
--- a/netlib/http.py
+++ b/netlib/http.py
@@ -43,6 +43,8 @@ def parse_url(url):
         return None
     if not scheme:
         return None
+    if '@' in netloc:
+        _, netloc = string.rsplit(netloc, '@', maxsplit=1)
     if ':' in netloc:
         host, port = string.rsplit(netloc, ':', maxsplit=1)
         try:


### PR DESCRIPTION
When url has username:password segments, netloc has them too.

``` python
>>> scheme, netloc = urlparse.urlparse('http://username:password@server:port/path')
>>> netloc
'username:password@server'
```

This removes these credentials from `netloc`
