### PR TITLE
ensuring length is cast an an int when adding len(data)

### DIFF
--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -152,6 +152,8 @@ class Reader(_FileLike):
                 break
             result += data
             if length != -1:
+		if type(length) != int:
+                        length = int(length)
                 length -= len(data)
         self.add_log(result)
         return result


### PR DESCRIPTION
This fixes an error when length is not cast as an int when provided to this function.  Found this error on Kali Linux using v 0.10.
