### PR TITLE
implement basic HTTP/2 frame classes

### DIFF
--- a/netlib/h2/__init__.py
+++ b/netlib/h2/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import (absolute_import, print_function, division)

--- a/netlib/h2/frame.py
+++ b/netlib/h2/frame.py
@@ -1,0 +1,375 @@
+import base64
+import hashlib
+import os
+import struct
+import io
+
+from .. import utils, odict, tcp
+
+class Frame(object):
+    """
+        Baseclass Frame
+        contains header
+        payload is defined in subclasses
+    """
+
+    FLAG_NO_FLAGS = 0x0
+    FLAG_ACK = 0x1
+    FLAG_END_STREAM = 0x1
+    FLAG_END_HEADERS = 0x4
+    FLAG_PADDED = 0x8
+    FLAG_PRIORITY = 0x20
+
+    def __init__(self, length, flags, stream_id):
+        valid_flags = reduce(lambda x, y: x | y, self.VALID_FLAGS, 0x0)
+        if flags | valid_flags != valid_flags:
+            raise ValueError('invalid flags detected.')
+
+        self.length = length
+        self.flags = flags
+        self.stream_id = stream_id
+
+    @classmethod
+    def from_bytes(self, data):
+        fields = struct.unpack("!HBBBL", data[:9])
+        length = (fields[0] << 8) + fields[1]
+        # type is already deducted from class
+        flags = fields[3]
+        stream_id = fields[4]
+        return FRAMES[fields[2]].from_bytes(length, flags, stream_id, data[9:])
+
+    def to_bytes(self):
+        payload = self.payload_bytes()
+        self.length = len(payload)
+
+        b = struct.pack('!HB', self.length & 0xFFFF00, self.length & 0x0000FF)
+        b += struct.pack('!B', self.TYPE)
+        b += struct.pack('!B', self.flags)
+        b += struct.pack('!L', self.stream_id & 0x7FFFFFFF)
+        b += payload
+
+        return b
+
+    def __eq__(self, other):
+        return self.to_bytes() == other.to_bytes()
+
+class DataFrame(Frame):
+    TYPE = 0x0
+    VALID_FLAGS = [Frame.FLAG_END_STREAM, Frame.FLAG_PADDED]
+
+    def __init__(self, length=0, flags=Frame.FLAG_NO_FLAGS, stream_id=0x0, payload=b'', pad_length=0):
+        super(DataFrame, self).__init__(length, flags, stream_id)
+        self.payload = payload
+        self.pad_length = pad_length
+
+    @classmethod
+    def from_bytes(self, length, flags, stream_id, payload):
+        f = self(length=length, flags=flags, stream_id=stream_id)
+
+        if f.flags & self.FLAG_PADDED:
+            f.pad_length = struct.unpack('!B', payload[0])[0]
+            f.payload = payload[1:-f.pad_length]
+        else:
+            f.payload = payload
+
+        return f
+
+    def payload_bytes(self):
+        if self.stream_id == 0x0:
+            raise ValueError('DATA frames MUST be associated with a stream.')
+
+        b = b''
+        if self.flags & self.FLAG_PADDED:
+            b += struct.pack('!B', self.pad_length)
+
+        b += bytes(self.payload)
+
+        if self.flags & self.FLAG_PADDED:
+            b += b'\0' * self.pad_length
+
+        return b
+
+class HeadersFrame(Frame):
+    TYPE = 0x1
+    VALID_FLAGS = [Frame.FLAG_END_STREAM, Frame.FLAG_END_HEADERS, Frame.FLAG_PADDED, Frame.FLAG_PRIORITY]
+
+    def __init__(self, length=0, flags=Frame.FLAG_NO_FLAGS, stream_id=0x0, header_block_fragment=b'', pad_length=0, exclusive=False, stream_dependency=0x0, weight=0):
+        super(HeadersFrame, self).__init__(length, flags, stream_id)
+        self.header_block_fragment = header_block_fragment
+        self.pad_length = pad_length
+        self.exclusive = exclusive
+        self.stream_dependency = stream_dependency
+        self.weight = weight
+
+    @classmethod
+    def from_bytes(self, length, flags, stream_id, payload):
+        f = self(length=length, flags=flags, stream_id=stream_id)
+
+        if f.flags & self.FLAG_PADDED:
+            f.pad_length = struct.unpack('!B', payload[0])[0]
+            f.header_block_fragment = payload[1:-f.pad_length]
+        else:
+            f.header_block_fragment = payload[0:]
+
+        if f.flags & self.FLAG_PRIORITY:
+            f.stream_dependency, f.weight = struct.unpack('!LB', f.header_block_fragment[:5])
+            f.exclusive = bool(f.stream_dependency >> 31)
+            f.stream_dependency &= 0x7FFFFFFF
+            f.header_block_fragment = f.header_block_fragment[5:]
+
+        return f
+
+    def payload_bytes(self):
+        if self.stream_id == 0x0:
+            raise ValueError('HEADERS frames MUST be associated with a stream.')
+
+        b = b''
+        if self.flags & self.FLAG_PADDED:
+            b += struct.pack('!B', self.pad_length)
+
+        if self.flags & self.FLAG_PRIORITY:
+            b += struct.pack('!LB', (int(self.exclusive) << 31) | self.stream_dependency, self.weight)
+
+        b += bytes(self.header_block_fragment)
+
+        if self.flags & self.FLAG_PADDED:
+            b += b'\0' * self.pad_length
+
+        return b
+
+class PriorityFrame(Frame):
+    TYPE = 0x2
+    VALID_FLAGS = []
+
+    def __init__(self, length=0, flags=Frame.FLAG_NO_FLAGS, stream_id=0x0, exclusive=False, stream_dependency=0x0, weight=0):
+        super(PriorityFrame, self).__init__(length, flags, stream_id)
+        self.exclusive = exclusive
+        self.stream_dependency = stream_dependency
+        self.weight = weight
+
+    @classmethod
+    def from_bytes(self, length, flags, stream_id, payload):
+        f = self(length=length, flags=flags, stream_id=stream_id)
+
+        f.stream_dependency, f.weight = struct.unpack('!LB', payload)
+        f.exclusive = bool(f.stream_dependency >> 31)
+        f.stream_dependency &= 0x7FFFFFFF
+
+        return f
+
+    def payload_bytes(self):
+        if self.stream_id == 0x0:
+            raise ValueError('PRIORITY frames MUST be associated with a stream.')
+
+        if self.stream_dependency == 0x0:
+            raise ValueError('stream dependency is invalid.')
+
+        return struct.pack('!LB', (int(self.exclusive) << 31) | self.stream_dependency, self.weight)
+
+class RstStreamFrame(Frame):
+    TYPE = 0x3
+    VALID_FLAGS = []
+
+    def __init__(self, length=0, flags=Frame.FLAG_NO_FLAGS, stream_id=0x0, error_code=0x0):
+        super(RstStreamFrame, self).__init__(length, flags, stream_id)
+        self.error_code = error_code
+
+    @classmethod
+    def from_bytes(self, length, flags, stream_id, payload):
+        f = self(length=length, flags=flags, stream_id=stream_id)
+        f.error_code = struct.unpack('!L', payload)[0]
+        return f
+
+    def payload_bytes(self):
+        if self.stream_id == 0x0:
+            raise ValueError('RST_STREAM frames MUST be associated with a stream.')
+
+        return struct.pack('!L', self.error_code)
+
+class SettingsFrame(Frame):
+    TYPE = 0x4
+    VALID_FLAGS = [Frame.FLAG_ACK]
+
+    SETTINGS = utils.BiDi(
+        SETTINGS_HEADER_TABLE_SIZE = 0x1,
+        SETTINGS_ENABLE_PUSH = 0x2,
+        SETTINGS_MAX_CONCURRENT_STREAMS = 0x3,
+        SETTINGS_INITIAL_WINDOW_SIZE = 0x4,
+        SETTINGS_MAX_FRAME_SIZE = 0x5,
+        SETTINGS_MAX_HEADER_LIST_SIZE = 0x6,
+        )
+
+    def __init__(self, length=0, flags=Frame.FLAG_NO_FLAGS, stream_id=0x0, settings={}):
+        super(SettingsFrame, self).__init__(length, flags, stream_id)
+        self.settings = settings
+
+    @classmethod
+    def from_bytes(self, length, flags, stream_id, payload):
+        f = self(length=length, flags=flags, stream_id=stream_id)
+
+        for i in xrange(0, len(payload), 6):
+            identifier, value = struct.unpack("!HL", payload[i:i+6])
+            f.settings[identifier] = value
+
+        return f
+
+    def payload_bytes(self):
+        if self.stream_id != 0x0:
+            raise ValueError('SETTINGS frames MUST NOT be associated with a stream.')
+
+        b = b''
+        for identifier, value in self.settings.items():
+            b += struct.pack("!HL", identifier & 0xFF, value)
+
+        return b
+
+class PushPromiseFrame(Frame):
+    TYPE = 0x5
+    VALID_FLAGS = [Frame.FLAG_END_HEADERS, Frame.FLAG_PADDED]
+
+    def __init__(self, length=0, flags=Frame.FLAG_NO_FLAGS, stream_id=0x0, promised_stream=0x0, header_block_fragment=b'', pad_length=0):
+        super(PushPromiseFrame, self).__init__(length, flags, stream_id)
+        self.pad_length = pad_length
+        self.promised_stream = promised_stream
+        self.header_block_fragment = header_block_fragment
+
+    @classmethod
+    def from_bytes(self, length, flags, stream_id, payload):
+        f = self(length=length, flags=flags, stream_id=stream_id)
+
+        if f.flags & self.FLAG_PADDED:
+            f.pad_length, f.promised_stream = struct.unpack('!BL', payload[:5])
+            f.header_block_fragment = payload[5:-f.pad_length]
+        else:
+            f.promised_stream = int(struct.unpack("!L", payload[:4])[0])
+            f.header_block_fragment = payload[4:]
+
+        f.promised_stream &= 0x7FFFFFFF
+
+        return f
+
+    def payload_bytes(self):
+        if self.stream_id == 0x0:
+            raise ValueError('PUSH_PROMISE frames MUST be associated with a stream.')
+
+        if self.promised_stream == 0x0:
+            raise ValueError('Promised stream id not valid.')
+
+        b = b''
+        if self.flags & self.FLAG_PADDED:
+            b += struct.pack('!B', self.pad_length)
+
+        b += struct.pack('!L', self.promised_stream & 0x7FFFFFFF)
+        b += bytes(self.header_block_fragment)
+
+        if self.flags & self.FLAG_PADDED:
+            b += b'\0' * self.pad_length
+
+        return b
+
+class PingFrame(Frame):
+    TYPE = 0x6
+    VALID_FLAGS = [Frame.FLAG_ACK]
+
+    def __init__(self, length=0, flags=Frame.FLAG_NO_FLAGS, stream_id=0x0, payload=b''):
+        super(PingFrame, self).__init__(length, flags, stream_id)
+        self.payload = payload
+
+    @classmethod
+    def from_bytes(self, length, flags, stream_id, payload):
+        f = self(length=length, flags=flags, stream_id=stream_id)
+        f.payload = payload
+        return f
+
+    def payload_bytes(self):
+        if self.stream_id != 0x0:
+            raise ValueError('PING frames MUST NOT be associated with a stream.')
+
+        b = self.payload[0:8]
+        b += b'\0' * (8 - len(b))
+        return b
+
+class GoAwayFrame(Frame):
+    TYPE = 0x7
+    VALID_FLAGS = []
+
+    def __init__(self, length=0, flags=Frame.FLAG_NO_FLAGS, stream_id=0x0, last_stream=0x0, error_code=0x0, data=b''):
+        super(GoAwayFrame, self).__init__(length, flags, stream_id)
+        self.last_stream = last_stream
+        self.error_code = error_code
+        self.data = data
+
+    @classmethod
+    def from_bytes(self, length, flags, stream_id, payload):
+        f = self(length=length, flags=flags, stream_id=stream_id)
+
+        f.last_stream, f.error_code = struct.unpack("!LL", payload[:8])
+        f.last_stream &= 0x7FFFFFFF
+        f.data = payload[8:]
+
+        return f
+
+    def payload_bytes(self):
+        if self.stream_id != 0x0:
+            raise ValueError('GOAWAY frames MUST NOT be associated with a stream.')
+
+        b = struct.pack('!LL', self.last_stream & 0x7FFFFFFF, self.error_code)
+        b += bytes(self.data)
+        return b
+
+class WindowUpdateFrame(Frame):
+    TYPE = 0x8
+    VALID_FLAGS = []
+
+    def __init__(self, length=0, flags=Frame.FLAG_NO_FLAGS, stream_id=0x0, window_size_increment=0x0):
+        super(WindowUpdateFrame, self).__init__(length, flags, stream_id)
+        self.window_size_increment = window_size_increment
+
+    @classmethod
+    def from_bytes(self, length, flags, stream_id, payload):
+        f = self(length=length, flags=flags, stream_id=stream_id)
+
+        f.window_size_increment = struct.unpack("!L", payload)[0]
+        f.window_size_increment &= 0x7FFFFFFF
+
+        return f
+
+    def payload_bytes(self):
+        if self.window_size_increment <= 0 or self.window_size_increment >= 2**31:
+            raise ValueError('Window Szie Increment MUST be greater than 0 and less than 2^31.')
+
+        return struct.pack('!L', self.window_size_increment & 0x7FFFFFFF)
+
+class ContinuationFrame(Frame):
+    TYPE = 0x9
+    VALID_FLAGS = [Frame.FLAG_END_HEADERS]
+
+    def __init__(self, length=0, flags=Frame.FLAG_NO_FLAGS, stream_id=0x0, header_block_fragment=b''):
+        super(ContinuationFrame, self).__init__(length, flags, stream_id)
+        self.header_block_fragment = header_block_fragment
+
+    @classmethod
+    def from_bytes(self, length, flags, stream_id, payload):
+        f = self(length=length, flags=flags, stream_id=stream_id)
+        f.header_block_fragment = payload
+        return f
+
+    def payload_bytes(self):
+        if self.stream_id == 0x0:
+            raise ValueError('CONTINUATION frames MUST be associated with a stream.')
+
+        return self.header_block_fragment
+
+_FRAME_CLASSES = [
+    DataFrame,
+    HeadersFrame,
+    PriorityFrame,
+    RstStreamFrame,
+    SettingsFrame,
+    PushPromiseFrame,
+    PingFrame,
+    GoAwayFrame,
+    WindowUpdateFrame,
+    ContinuationFrame
+]
+FRAMES = {cls.TYPE: cls for cls in _FRAME_CLASSES}

--- a/netlib/h2/h2.py
+++ b/netlib/h2/h2.py
@@ -1,0 +1,25 @@
+import base64
+import hashlib
+import os
+import struct
+import io
+
+# "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+CLIENT_CONNECTION_PREFACE = '505249202a20485454502f322e300d0a0d0a534d0d0a0d0a'
+
+ERROR_CODES = utils.BiDi(
+    NO_ERROR = 0x0,
+    PROTOCOL_ERROR = 0x1,
+    INTERNAL_ERROR = 0x2,
+    FLOW_CONTROL_ERROR = 0x3,
+    SETTINGS_TIMEOUT = 0x4,
+    STREAM_CLOSED = 0x5,
+    FRAME_SIZE_ERROR = 0x6,
+    REFUSED_STREAM = 0x7,
+    CANCEL = 0x8,
+    COMPRESSION_ERROR = 0x9,
+    CONNECT_ERROR = 0xa,
+    ENHANCE_YOUR_CALM = 0xb,
+    INADEQUATE_SECURITY = 0xc,
+    HTTP_1_1_REQUIRED = 0xd
+    )

--- a/test/h2/test_frames.py
+++ b/test/h2/test_frames.py
@@ -1,0 +1,341 @@
+from netlib.h2.frame import *
+import tutils
+
+from nose.tools import assert_equal
+
+
+
+# TODO test stream association if valid or not
+
+def test_invalid_flags():
+    tutils.raises(ValueError, DataFrame, ContinuationFrame.FLAG_END_HEADERS, 0x1234567, 'foobar')
+
+def test_frame_equality():
+    a = DataFrame(6, Frame.FLAG_END_STREAM, 0x1234567, 'foobar')
+    b = DataFrame(6, Frame.FLAG_END_STREAM, 0x1234567, 'foobar')
+    assert_equal(a, b)
+
+def test_too_large_frames():
+    DataFrame(6, Frame.FLAG_END_STREAM, 0x1234567)
+
+def test_data_frame_to_bytes():
+    f = DataFrame(6, Frame.FLAG_END_STREAM, 0x1234567, 'foobar')
+    assert_equal(f.to_bytes().encode('hex'), '000006000101234567666f6f626172')
+
+    f = DataFrame(11, Frame.FLAG_END_STREAM | Frame.FLAG_PADDED, 0x1234567, 'foobar', pad_length=3)
+    assert_equal(f.to_bytes().encode('hex'), '00000a00090123456703666f6f626172000000')
+
+    f = DataFrame(6, Frame.FLAG_NO_FLAGS, 0x0, 'foobar')
+    tutils.raises(ValueError, f.to_bytes)
+
+def test_data_frame_from_bytes():
+    f = Frame.from_bytes('000006000101234567666f6f626172'.decode('hex'))
+    assert isinstance(f, DataFrame)
+    assert_equal(f.length, 6)
+    assert_equal(f.TYPE, DataFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_END_STREAM)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.payload, 'foobar')
+
+    f = Frame.from_bytes('00000a00090123456703666f6f626172000000'.decode('hex'))
+    assert isinstance(f, DataFrame)
+    assert_equal(f.length, 10)
+    assert_equal(f.TYPE, DataFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_END_STREAM | Frame.FLAG_PADDED)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.payload, 'foobar')
+
+def test_headers_frame_to_bytes():
+    f = HeadersFrame(6, Frame.FLAG_NO_FLAGS, 0x1234567, 'foobar')
+    assert_equal(f.to_bytes().encode('hex'), '000006010001234567666f6f626172')
+
+    f = HeadersFrame(10, HeadersFrame.FLAG_PADDED, 0x1234567, 'foobar', pad_length=3)
+    assert_equal(f.to_bytes().encode('hex'), '00000a01080123456703666f6f626172000000')
+
+    f = HeadersFrame(10, HeadersFrame.FLAG_PRIORITY, 0x1234567, 'foobar', exclusive=True, stream_dependency=0x7654321, weight=42)
+    assert_equal(f.to_bytes().encode('hex'), '00000b012001234567876543212a666f6f626172')
+
+    f = HeadersFrame(14, HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY, 0x1234567, 'foobar', pad_length=3, exclusive=True, stream_dependency=0x7654321, weight=42)
+    assert_equal(f.to_bytes().encode('hex'), '00000f01280123456703876543212a666f6f626172000000')
+
+    f = HeadersFrame(14, HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY, 0x1234567, 'foobar', pad_length=3, exclusive=False, stream_dependency=0x7654321, weight=42)
+    assert_equal(f.to_bytes().encode('hex'), '00000f01280123456703076543212a666f6f626172000000')
+
+    f = HeadersFrame(6, Frame.FLAG_NO_FLAGS, 0x0, 'foobar')
+    tutils.raises(ValueError, f.to_bytes)
+
+def test_headers_frame_from_bytes():
+    f = Frame.from_bytes('000006010001234567666f6f626172'.decode('hex'))
+    assert isinstance(f, HeadersFrame)
+    assert_equal(f.length, 6)
+    assert_equal(f.TYPE, HeadersFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_NO_FLAGS)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.header_block_fragment, 'foobar')
+
+    f = Frame.from_bytes('00000a01080123456703666f6f626172000000'.decode('hex'))
+    assert isinstance(f, HeadersFrame)
+    assert_equal(f.length, 10)
+    assert_equal(f.TYPE, HeadersFrame.TYPE)
+    assert_equal(f.flags, HeadersFrame.FLAG_PADDED)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.header_block_fragment, 'foobar')
+
+    f = Frame.from_bytes('00000b012001234567876543212a666f6f626172'.decode('hex'))
+    assert isinstance(f, HeadersFrame)
+    assert_equal(f.length, 11)
+    assert_equal(f.TYPE, HeadersFrame.TYPE)
+    assert_equal(f.flags, HeadersFrame.FLAG_PRIORITY)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.header_block_fragment, 'foobar')
+    assert_equal(f.exclusive, True)
+    assert_equal(f.stream_dependency, 0x7654321)
+    assert_equal(f.weight, 42)
+
+    f = Frame.from_bytes('00000f01280123456703876543212a666f6f626172000000'.decode('hex'))
+    assert isinstance(f, HeadersFrame)
+    assert_equal(f.length, 15)
+    assert_equal(f.TYPE, HeadersFrame.TYPE)
+    assert_equal(f.flags, HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.header_block_fragment, 'foobar')
+    assert_equal(f.exclusive, True)
+    assert_equal(f.stream_dependency, 0x7654321)
+    assert_equal(f.weight, 42)
+
+    f = Frame.from_bytes('00000f01280123456703076543212a666f6f626172000000'.decode('hex'))
+    assert isinstance(f, HeadersFrame)
+    assert_equal(f.length, 15)
+    assert_equal(f.TYPE, HeadersFrame.TYPE)
+    assert_equal(f.flags, HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.header_block_fragment, 'foobar')
+    assert_equal(f.exclusive, False)
+    assert_equal(f.stream_dependency, 0x7654321)
+    assert_equal(f.weight, 42)
+
+def test_priority_frame_to_bytes():
+    f = PriorityFrame(5, Frame.FLAG_NO_FLAGS, 0x1234567, exclusive=True, stream_dependency=0x7654321, weight=42)
+    assert_equal(f.to_bytes().encode('hex'), '000005020001234567876543212a')
+
+    f = PriorityFrame(5, Frame.FLAG_NO_FLAGS, 0x1234567, exclusive=False, stream_dependency=0x7654321, weight=21)
+    assert_equal(f.to_bytes().encode('hex'), '0000050200012345670765432115')
+
+    f = PriorityFrame(5, Frame.FLAG_NO_FLAGS, 0x0, stream_dependency=0x1234567)
+    tutils.raises(ValueError, f.to_bytes)
+
+    f = PriorityFrame(5, Frame.FLAG_NO_FLAGS, 0x1234567, stream_dependency=0x0)
+    tutils.raises(ValueError, f.to_bytes)
+
+def test_priority_frame_from_bytes():
+    f = Frame.from_bytes('000005020001234567876543212a'.decode('hex'))
+    assert isinstance(f, PriorityFrame)
+    assert_equal(f.length, 5)
+    assert_equal(f.TYPE, PriorityFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_NO_FLAGS)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.exclusive, True)
+    assert_equal(f.stream_dependency, 0x7654321)
+    assert_equal(f.weight, 42)
+
+    f = Frame.from_bytes('0000050200012345670765432115'.decode('hex'))
+    assert isinstance(f, PriorityFrame)
+    assert_equal(f.length, 5)
+    assert_equal(f.TYPE, PriorityFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_NO_FLAGS)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.exclusive, False)
+    assert_equal(f.stream_dependency, 0x7654321)
+    assert_equal(f.weight, 21)
+
+def test_rst_stream_frame_to_bytes():
+    f = RstStreamFrame(4, Frame.FLAG_NO_FLAGS, 0x1234567, error_code=0x7654321)
+    assert_equal(f.to_bytes().encode('hex'), '00000403000123456707654321')
+
+    f = RstStreamFrame(4, Frame.FLAG_NO_FLAGS, 0x0)
+    tutils.raises(ValueError, f.to_bytes)
+
+def test_rst_stream_frame_from_bytes():
+    f = Frame.from_bytes('00000403000123456707654321'.decode('hex'))
+    assert isinstance(f, RstStreamFrame)
+    assert_equal(f.length, 4)
+    assert_equal(f.TYPE, RstStreamFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_NO_FLAGS)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.error_code, 0x07654321)
+
+def test_settings_frame_to_bytes():
+    f = SettingsFrame(0, Frame.FLAG_NO_FLAGS, 0x0)
+    assert_equal(f.to_bytes().encode('hex'), '000000040000000000')
+
+    f = SettingsFrame(0, SettingsFrame.FLAG_ACK, 0x0)
+    assert_equal(f.to_bytes().encode('hex'), '000000040100000000')
+
+    f = SettingsFrame(6, SettingsFrame.FLAG_ACK, 0x0, settings={SettingsFrame.SETTINGS.SETTINGS_ENABLE_PUSH: 1})
+    assert_equal(f.to_bytes().encode('hex'), '000006040100000000000200000001')
+
+    f = SettingsFrame(12, Frame.FLAG_NO_FLAGS, 0x0, settings={SettingsFrame.SETTINGS.SETTINGS_ENABLE_PUSH: 1, SettingsFrame.SETTINGS.SETTINGS_MAX_CONCURRENT_STREAMS: 0x12345678})
+    assert_equal(f.to_bytes().encode('hex'), '00000c040000000000000200000001000312345678')
+
+    f = SettingsFrame(0, Frame.FLAG_NO_FLAGS, 0x1234567)
+    tutils.raises(ValueError, f.to_bytes)
+
+def test_settings_frame_from_bytes():
+    f = Frame.from_bytes('000000040000000000'.decode('hex'))
+    assert isinstance(f, SettingsFrame)
+    assert_equal(f.length, 0)
+    assert_equal(f.TYPE, SettingsFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_NO_FLAGS)
+    assert_equal(f.stream_id, 0x0)
+
+    f = Frame.from_bytes('000000040100000000'.decode('hex'))
+    assert isinstance(f, SettingsFrame)
+    assert_equal(f.length, 0)
+    assert_equal(f.TYPE, SettingsFrame.TYPE)
+    assert_equal(f.flags, SettingsFrame.FLAG_ACK)
+    assert_equal(f.stream_id, 0x0)
+
+    f = Frame.from_bytes('000006040100000000000200000001'.decode('hex'))
+    assert isinstance(f, SettingsFrame)
+    assert_equal(f.length, 6)
+    assert_equal(f.TYPE, SettingsFrame.TYPE)
+    assert_equal(f.flags, SettingsFrame.FLAG_ACK, 0x0)
+    assert_equal(f.stream_id, 0x0)
+    assert_equal(len(f.settings), 1)
+    assert_equal(f.settings[SettingsFrame.SETTINGS.SETTINGS_ENABLE_PUSH], 1)
+
+    f = Frame.from_bytes('00000c040000000000000200000001000312345678'.decode('hex'))
+    assert isinstance(f, SettingsFrame)
+    assert_equal(f.length, 12)
+    assert_equal(f.TYPE, SettingsFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_NO_FLAGS)
+    assert_equal(f.stream_id, 0x0)
+    assert_equal(len(f.settings), 2)
+    assert_equal(f.settings[SettingsFrame.SETTINGS.SETTINGS_ENABLE_PUSH], 1)
+    assert_equal(f.settings[SettingsFrame.SETTINGS.SETTINGS_MAX_CONCURRENT_STREAMS], 0x12345678)
+
+def test_push_promise_frame_to_bytes():
+    f = PushPromiseFrame(10, Frame.FLAG_NO_FLAGS, 0x1234567, 0x7654321, 'foobar')
+    assert_equal(f.to_bytes().encode('hex'), '00000a05000123456707654321666f6f626172')
+
+    f = PushPromiseFrame(14, HeadersFrame.FLAG_PADDED, 0x1234567, 0x7654321, 'foobar', pad_length=3)
+    assert_equal(f.to_bytes().encode('hex'), '00000e0508012345670307654321666f6f626172000000')
+
+    f = PushPromiseFrame(4, Frame.FLAG_NO_FLAGS, 0x0, 0x1234567)
+    tutils.raises(ValueError, f.to_bytes)
+
+    f = PushPromiseFrame(4, Frame.FLAG_NO_FLAGS, 0x1234567, 0x0)
+    tutils.raises(ValueError, f.to_bytes)
+
+def test_push_promise_frame_from_bytes():
+    f = Frame.from_bytes('00000a05000123456707654321666f6f626172'.decode('hex'))
+    assert isinstance(f, PushPromiseFrame)
+    assert_equal(f.length, 10)
+    assert_equal(f.TYPE, PushPromiseFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_NO_FLAGS)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.header_block_fragment, 'foobar')
+
+    f = Frame.from_bytes('00000e0508012345670307654321666f6f626172000000'.decode('hex'))
+    assert isinstance(f, PushPromiseFrame)
+    assert_equal(f.length, 14)
+    assert_equal(f.TYPE, PushPromiseFrame.TYPE)
+    assert_equal(f.flags, PushPromiseFrame.FLAG_PADDED)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.header_block_fragment, 'foobar')
+
+def test_ping_frame_to_bytes():
+    f = PingFrame(8, PingFrame.FLAG_ACK, 0x0, payload=b'foobar')
+    assert_equal(f.to_bytes().encode('hex'), '000008060100000000666f6f6261720000')
+
+    f = PingFrame(8, Frame.FLAG_NO_FLAGS, 0x0, payload=b'foobardeadbeef')
+    assert_equal(f.to_bytes().encode('hex'), '000008060000000000666f6f6261726465')
+
+    f = PingFrame(8, Frame.FLAG_NO_FLAGS, 0x1234567)
+    tutils.raises(ValueError, f.to_bytes)
+
+def test_ping_frame_from_bytes():
+    f = Frame.from_bytes('000008060100000000666f6f6261720000'.decode('hex'))
+    assert isinstance(f, PingFrame)
+    assert_equal(f.length, 8)
+    assert_equal(f.TYPE, PingFrame.TYPE)
+    assert_equal(f.flags, PingFrame.FLAG_ACK)
+    assert_equal(f.stream_id, 0x0)
+    assert_equal(f.payload, b'foobar\0\0')
+
+    f = Frame.from_bytes('000008060000000000666f6f6261726465'.decode('hex'))
+    assert isinstance(f, PingFrame)
+    assert_equal(f.length, 8)
+    assert_equal(f.TYPE, PingFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_NO_FLAGS)
+    assert_equal(f.stream_id, 0x0)
+    assert_equal(f.payload, b'foobarde')
+
+def test_goaway_frame_to_bytes():
+    f = GoAwayFrame(8, Frame.FLAG_NO_FLAGS, 0x0, last_stream=0x1234567, error_code=0x87654321, data=b'')
+    assert_equal(f.to_bytes().encode('hex'), '0000080700000000000123456787654321')
+
+    f = GoAwayFrame(14, Frame.FLAG_NO_FLAGS, 0x0, last_stream=0x1234567, error_code=0x87654321, data=b'foobar')
+    assert_equal(f.to_bytes().encode('hex'), '00000e0700000000000123456787654321666f6f626172')
+
+    f = GoAwayFrame(8, Frame.FLAG_NO_FLAGS, 0x1234567, last_stream=0x1234567, error_code=0x87654321)
+    tutils.raises(ValueError, f.to_bytes)
+
+def test_goaway_frame_from_bytes():
+    f = Frame.from_bytes('0000080700000000000123456787654321'.decode('hex'))
+    assert isinstance(f, GoAwayFrame)
+    assert_equal(f.length, 8)
+    assert_equal(f.TYPE, GoAwayFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_NO_FLAGS)
+    assert_equal(f.stream_id, 0x0)
+    assert_equal(f.last_stream, 0x1234567)
+    assert_equal(f.error_code, 0x87654321)
+    assert_equal(f.data, b'')
+
+    f = Frame.from_bytes('00000e0700000000000123456787654321666f6f626172'.decode('hex'))
+    assert isinstance(f, GoAwayFrame)
+    assert_equal(f.length, 14)
+    assert_equal(f.TYPE, GoAwayFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_NO_FLAGS)
+    assert_equal(f.stream_id, 0x0)
+    assert_equal(f.last_stream, 0x1234567)
+    assert_equal(f.error_code, 0x87654321)
+    assert_equal(f.data, b'foobar')
+
+def test_window_update_frame_to_bytes():
+    f = WindowUpdateFrame(4, Frame.FLAG_NO_FLAGS, 0x0, window_size_increment=0x1234567)
+    assert_equal(f.to_bytes().encode('hex'), '00000408000000000001234567')
+
+    f = WindowUpdateFrame(4, Frame.FLAG_NO_FLAGS, 0x1234567, window_size_increment=0x7654321)
+    assert_equal(f.to_bytes().encode('hex'), '00000408000123456707654321')
+
+    f = WindowUpdateFrame(4, Frame.FLAG_NO_FLAGS, 0x0, window_size_increment=0xdeadbeef)
+    tutils.raises(ValueError, f.to_bytes)
+
+    f = WindowUpdateFrame(4, Frame.FLAG_NO_FLAGS, 0x0, window_size_increment=0)
+    tutils.raises(ValueError, f.to_bytes)
+
+def test_window_update_frame_from_bytes():
+    f = Frame.from_bytes('00000408000000000001234567'.decode('hex'))
+    assert isinstance(f, WindowUpdateFrame)
+    assert_equal(f.length, 4)
+    assert_equal(f.TYPE, WindowUpdateFrame.TYPE)
+    assert_equal(f.flags, Frame.FLAG_NO_FLAGS)
+    assert_equal(f.stream_id, 0x0)
+    assert_equal(f.window_size_increment, 0x1234567)
+
+def test_continuation_frame_to_bytes():
+    f = ContinuationFrame(6, ContinuationFrame.FLAG_END_HEADERS, 0x1234567, 'foobar')
+    assert_equal(f.to_bytes().encode('hex'), '000006090401234567666f6f626172')
+
+    f = ContinuationFrame(6, ContinuationFrame.FLAG_END_HEADERS, 0x0, 'foobar')
+    tutils.raises(ValueError, f.to_bytes)
+
+def test_continuation_frame_from_bytes():
+    f = Frame.from_bytes('000006090401234567666f6f626172'.decode('hex'))
+    assert isinstance(f, ContinuationFrame)
+    assert_equal(f.length, 6)
+    assert_equal(f.TYPE, ContinuationFrame.TYPE)
+    assert_equal(f.flags, ContinuationFrame.FLAG_END_HEADERS)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.header_block_fragment, 'foobar')


### PR DESCRIPTION
* implement all HTTP/2 frames
* test `to_bytes` and `from_bytes` for writing and reading of raw data
* no integration with netlib in any way - just plain python classes