### PR TITLE
Update openssl

### DIFF
--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -307,10 +307,10 @@ class _Connection(object):
     def get_current_cipher(self):
         if not self.ssl_established:
             return None
-        c = SSL._lib.SSL_get_current_cipher(self.connection._ssl)
-        name = SSL._native(SSL._ffi.string(SSL._lib.SSL_CIPHER_get_name(c)))
-        bits = SSL._lib.SSL_CIPHER_get_bits(c, SSL._ffi.NULL)
-        version = SSL._native(SSL._ffi.string(SSL._lib.SSL_CIPHER_get_version(c)))
+
+        name = self.connection.get_cipher_name()
+        bits = self.connection.get_cipher_bits()
+        version = self.connection.get_cipher_version()
         return name, bits, version
 
     def finish(self):
@@ -333,10 +333,6 @@ class _Connection(object):
                 self.connection.shutdown()
             except SSL.Error:
                 pass
-            except KeyError as e:  # pragma: no cover
-                # Workaround for https://github.com/pyca/pyopenssl/pull/183
-                if OpenSSL.__version__ != "0.14":
-                    raise e
 
     """
     Creates an SSL Context.

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup(
 
     install_requires=[
         "pyasn1>=0.1.7",
-        "pyOpenSSL>=0.14",
+        "pyOpenSSL>=0.15.1",
+        "cryptography>=0.9",
         "passlib>=1.6.2"
     ],
     extras_require={


### PR DESCRIPTION
bumping pyOpenSSL to >= 0.15.1
and cryptography >= 0.9

This allows us to get rid of a few workarounds
and provides the foundation for ALPN - which is required for HTTP/2.

fixes #57 

Note:
for ALPN to actually work you need to (re)compile cryptography against openssl >= 1.0.2.
See https://cryptography.io/en/latest/installation/ on how to achieve this on your platform.