### PR TITLE
H2 client

### DIFF
--- a/netlib/h2/frame.py
+++ b/netlib/h2/frame.py
@@ -32,6 +32,23 @@ class Frame(object):
         self.stream_id = stream_id
 
     @classmethod
+    def from_file(self, fp):
+        """
+          read a HTTP/2 frame sent by a server or client
+          fp is a "file like" object that could be backed by a network
+          stream or a disk or an in memory stream reader
+        """
+        raw_header = fp.safe_read(9)
+
+        fields = struct.unpack("!HBBBL", raw_header)
+        length = (fields[0] << 8) + fields[1]
+        flags = fields[3]
+        stream_id = fields[4]
+
+        payload = fp.safe_read(length)
+        return FRAMES[fields[2]].from_bytes(length, flags, stream_id, payload)
+
+    @classmethod
     def from_bytes(self, data):
         fields = struct.unpack("!HBBBL", data[:9])
         length = (fields[0] << 8) + fields[1]

--- a/netlib/h2/frame.py
+++ b/netlib/h2/frame.py
@@ -245,8 +245,12 @@ class SettingsFrame(Frame):
         SETTINGS_MAX_HEADER_LIST_SIZE=0x6,
     )
 
-    def __init__(self, length=0, flags=Frame.FLAG_NO_FLAGS, stream_id=0x0, settings={}):
+    def __init__(self, length=0, flags=Frame.FLAG_NO_FLAGS, stream_id=0x0, settings=None):
         super(SettingsFrame, self).__init__(length, flags, stream_id)
+
+        if settings is None:
+            settings = {}
+
         self.settings = settings
 
     @classmethod

--- a/netlib/h2/frame.py
+++ b/netlib/h2/frame.py
@@ -1,5 +1,4 @@
 import struct
-import io
 from hpack.hpack import Encoder, Decoder
 
 from .. import utils

--- a/netlib/h2/h2.py
+++ b/netlib/h2/h2.py
@@ -1,3 +1,5 @@
+from .. import utils, odict, tcp
+from frame import *
 
 # "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
 CLIENT_CONNECTION_PREFACE = '505249202a20485454502f322e300d0a0d0a534d0d0a0d0a'
@@ -18,3 +20,66 @@ ERROR_CODES = utils.BiDi(
     INADEQUATE_SECURITY=0xc,
     HTTP_1_1_REQUIRED=0xd
 )
+
+
+class H2Client(tcp.TCPClient):
+    ALPN_PROTO_H2 = b'h2'
+
+    DEFAULT_SETTINGS = {
+        SettingsFrame.SETTINGS.SETTINGS_HEADER_TABLE_SIZE: 4096,
+        SettingsFrame.SETTINGS.SETTINGS_ENABLE_PUSH: 1,
+        SettingsFrame.SETTINGS.SETTINGS_MAX_CONCURRENT_STREAMS: None,
+        SettingsFrame.SETTINGS.SETTINGS_INITIAL_WINDOW_SIZE: 2 ^ 16 - 1,
+        SettingsFrame.SETTINGS.SETTINGS_MAX_FRAME_SIZE: 2 ^ 14,
+        SettingsFrame.SETTINGS.SETTINGS_MAX_HEADER_LIST_SIZE: None,
+    }
+
+    def __init__(self, address, source_address=None):
+        super(H2Client, self).__init__(address, source_address)
+        self.settings = self.DEFAULT_SETTINGS.copy()
+
+    def connect(self, send_preface=True):
+        super(H2Client, self).connect()
+        self.convert_to_ssl(alpn_protos=[self.ALPN_PROTO_H2])
+
+        alp = self.get_alpn_proto_negotiated()
+        if alp != b'h2':
+            raise NotImplementedError("H2Client can not handle unknown protocol: %s" % alp)
+        print "-> Successfully negotiated 'h2' application layer protocol."
+
+        if send_preface:
+            self.wfile.write(bytes(CLIENT_CONNECTION_PREFACE.decode('hex')))
+            self.send_frame(SettingsFrame())
+
+            frame = Frame.from_file(self.rfile)
+            print frame.human_readable()
+            assert isinstance(frame, SettingsFrame)
+            self.apply_settings(frame.settings)
+
+            print "-> Connection Preface completed."
+
+        print "-> H2Client is ready..."
+
+    def send_frame(self, frame):
+        self.wfile.write(frame.to_bytes())
+        self.wfile.flush()
+
+    def read_frame(self):
+        frame = Frame.from_file(self.rfile)
+        if isinstance(frame, SettingsFrame):
+            self.apply_settings(frame.settings)
+
+        return frame
+
+    def apply_settings(self, settings):
+        for setting, value in settings.items():
+            old_value = self.settings[setting]
+            if not old_value:
+                old_value = '-'
+
+            self.settings[setting] = value
+            print "-> Setting changed: %s to %d (was %s)" %
+                (SettingsFrame.SETTINGS.get_name(setting), value, str(old_value))
+
+        self.send_frame(SettingsFrame(flags=Frame.FLAG_ACK))
+        print "-> New settings acknowledged."

--- a/netlib/test.py
+++ b/netlib/test.py
@@ -82,7 +82,8 @@ class TServer(tcp.TCPServer):
                 request_client_cert=self.ssl["request_client_cert"],
                 cipher_list=self.ssl.get("cipher_list", None),
                 dhparams=self.ssl.get("dhparams", None),
-                chain_file=self.ssl.get("chain_file", None)
+                chain_file=self.ssl.get("chain_file", None),
+                alpn_select=self.ssl.get("alpn_select", None)
             )
         h.handle()
         h.finish()

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
         "pyasn1>=0.1.7",
         "pyOpenSSL>=0.15.1",
         "cryptography>=0.9",
-        "passlib>=1.6.2"
+        "passlib>=1.6.2",
+        "hpack>=1.0.1"
     ],
     extras_require={
         'dev': [

--- a/test/h2/example.py
+++ b/test/h2/example.py
@@ -1,0 +1,20 @@
+from netlib import tcp
+from netlib.h2.frame import *
+from netlib.h2.h2 import *
+from hpack.hpack import Encoder, Decoder
+
+c = H2Client(("127.0.0.1", 443))
+c.connect()
+
+c.send_frame(HeadersFrame(
+    flags=(Frame.FLAG_END_HEADERS | Frame.FLAG_END_STREAM),
+    stream_id=0x1,
+    headers=[
+        (b':method', 'GET'),
+        (b':path', b'/index.html'),
+        (b':scheme', b'https'),
+        (b':authority', b'localhost'),
+    ]))
+
+while True:
+    print c.read_frame().human_readable()

--- a/test/h2/example.py
+++ b/test/h2/example.py
@@ -1,7 +1,5 @@
-from netlib import tcp
 from netlib.h2.frame import *
 from netlib.h2.h2 import *
-from hpack.hpack import Encoder, Decoder
 
 c = H2Client(("127.0.0.1", 443))
 c.connect()

--- a/test/h2/test_frames.py
+++ b/test/h2/test_frames.py
@@ -5,16 +5,20 @@ from nose.tools import assert_equal
 
 # TODO test stream association if valid or not
 
+
 def test_invalid_flags():
     tutils.raises(ValueError, DataFrame, ContinuationFrame.FLAG_END_HEADERS, 0x1234567, 'foobar')
+
 
 def test_frame_equality():
     a = DataFrame(6, Frame.FLAG_END_STREAM, 0x1234567, 'foobar')
     b = DataFrame(6, Frame.FLAG_END_STREAM, 0x1234567, 'foobar')
     assert_equal(a, b)
 
+
 def test_too_large_frames():
     DataFrame(6, Frame.FLAG_END_STREAM, 0x1234567)
+
 
 def test_data_frame_to_bytes():
     f = DataFrame(6, Frame.FLAG_END_STREAM, 0x1234567, 'foobar')
@@ -25,6 +29,7 @@ def test_data_frame_to_bytes():
 
     f = DataFrame(6, Frame.FLAG_NO_FLAGS, 0x0, 'foobar')
     tutils.raises(ValueError, f.to_bytes)
+
 
 def test_data_frame_from_bytes():
     f = Frame.from_bytes('000006000101234567666f6f626172'.decode('hex'))
@@ -43,84 +48,138 @@ def test_data_frame_from_bytes():
     assert_equal(f.stream_id, 0x1234567)
     assert_equal(f.payload, 'foobar')
 
+
 def test_data_frame_human_readable():
     f = DataFrame(11, Frame.FLAG_END_STREAM | Frame.FLAG_PADDED, 0x1234567, 'foobar', pad_length=3)
     assert f.human_readable()
 
+
 def test_headers_frame_to_bytes():
-    f = HeadersFrame(6, Frame.FLAG_NO_FLAGS, 0x1234567, 'foobar')
-    assert_equal(f.to_bytes().encode('hex'), '000006010001234567666f6f626172')
+    f = HeadersFrame(
+        6,
+        Frame.FLAG_NO_FLAGS,
+        0x1234567,
+        headers=[('host', 'foo.bar')])
+    assert_equal(f.to_bytes().encode('hex'), '000007010001234567668594e75e31d9')
 
-    f = HeadersFrame(10, HeadersFrame.FLAG_PADDED, 0x1234567, 'foobar', pad_length=3)
-    assert_equal(f.to_bytes().encode('hex'), '00000a01080123456703666f6f626172000000')
+    f = HeadersFrame(
+        10,
+        HeadersFrame.FLAG_PADDED,
+        0x1234567,
+        headers=[('host', 'foo.bar')],
+        pad_length=3)
+    assert_equal(f.to_bytes().encode('hex'), '00000b01080123456703668594e75e31d9000000')
 
-    f = HeadersFrame(10, HeadersFrame.FLAG_PRIORITY, 0x1234567, 'foobar', exclusive=True, stream_dependency=0x7654321, weight=42)
-    assert_equal(f.to_bytes().encode('hex'), '00000b012001234567876543212a666f6f626172')
+    f = HeadersFrame(
+        10,
+        HeadersFrame.FLAG_PRIORITY,
+        0x1234567,
+        headers=[('host', 'foo.bar')],
+        exclusive=True,
+        stream_dependency=0x7654321,
+        weight=42)
+    assert_equal(f.to_bytes().encode('hex'), '00000c012001234567876543212a668594e75e31d9')
 
-    f = HeadersFrame(14, HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY, 0x1234567,
-                     'foobar', pad_length=3, exclusive=True, stream_dependency=0x7654321, weight=42)
-    assert_equal(f.to_bytes().encode('hex'), '00000f01280123456703876543212a666f6f626172000000')
+    f = HeadersFrame(
+        14,
+        HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY,
+        0x1234567,
+        headers=[('host', 'foo.bar')],
+        pad_length=3,
+        exclusive=True,
+        stream_dependency=0x7654321,
+        weight=42)
+    assert_equal(f.to_bytes().encode('hex'), '00001001280123456703876543212a668594e75e31d9000000')
 
-    f = HeadersFrame(14, HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY, 0x1234567, 'foobar',
-                     pad_length=3, exclusive=False, stream_dependency=0x7654321, weight=42)
-    assert_equal(f.to_bytes().encode('hex'), '00000f01280123456703076543212a666f6f626172000000')
+    f = HeadersFrame(
+        14,
+        HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY,
+        0x1234567,
+        headers=[('host', 'foo.bar')],
+        pad_length=3,
+        exclusive=False,
+        stream_dependency=0x7654321,
+        weight=42)
+    assert_equal(f.to_bytes().encode('hex'), '00001001280123456703076543212a668594e75e31d9000000')
 
     f = HeadersFrame(6, Frame.FLAG_NO_FLAGS, 0x0, 'foobar')
     tutils.raises(ValueError, f.to_bytes)
 
+
 def test_headers_frame_from_bytes():
-    f = Frame.from_bytes('000006010001234567666f6f626172'.decode('hex'))
+    f = Frame.from_bytes('000007010001234567668594e75e31d9'.decode('hex'))
     assert isinstance(f, HeadersFrame)
-    assert_equal(f.length, 6)
+    assert_equal(f.length, 7)
     assert_equal(f.TYPE, HeadersFrame.TYPE)
     assert_equal(f.flags, Frame.FLAG_NO_FLAGS)
     assert_equal(f.stream_id, 0x1234567)
-    assert_equal(f.header_block_fragment, 'foobar')
+    assert_equal(f.headers, [('host', 'foo.bar')])
 
-    f = Frame.from_bytes('00000a01080123456703666f6f626172000000'.decode('hex'))
-    assert isinstance(f, HeadersFrame)
-    assert_equal(f.length, 10)
-    assert_equal(f.TYPE, HeadersFrame.TYPE)
-    assert_equal(f.flags, HeadersFrame.FLAG_PADDED)
-    assert_equal(f.stream_id, 0x1234567)
-    assert_equal(f.header_block_fragment, 'foobar')
-
-    f = Frame.from_bytes('00000b012001234567876543212a666f6f626172'.decode('hex'))
+    f = Frame.from_bytes('00000b01080123456703668594e75e31d9000000'.decode('hex'))
     assert isinstance(f, HeadersFrame)
     assert_equal(f.length, 11)
     assert_equal(f.TYPE, HeadersFrame.TYPE)
+    assert_equal(f.flags, HeadersFrame.FLAG_PADDED)
+    assert_equal(f.stream_id, 0x1234567)
+    assert_equal(f.headers, [('host', 'foo.bar')])
+
+    f = Frame.from_bytes('00000c012001234567876543212a668594e75e31d9'.decode('hex'))
+    assert isinstance(f, HeadersFrame)
+    assert_equal(f.length, 12)
+    assert_equal(f.TYPE, HeadersFrame.TYPE)
     assert_equal(f.flags, HeadersFrame.FLAG_PRIORITY)
     assert_equal(f.stream_id, 0x1234567)
-    assert_equal(f.header_block_fragment, 'foobar')
+    assert_equal(f.headers, [('host', 'foo.bar')])
     assert_equal(f.exclusive, True)
     assert_equal(f.stream_dependency, 0x7654321)
     assert_equal(f.weight, 42)
 
-    f = Frame.from_bytes('00000f01280123456703876543212a666f6f626172000000'.decode('hex'))
+    f = Frame.from_bytes('00001001280123456703876543212a668594e75e31d9000000'.decode('hex'))
     assert isinstance(f, HeadersFrame)
-    assert_equal(f.length, 15)
+    assert_equal(f.length, 16)
     assert_equal(f.TYPE, HeadersFrame.TYPE)
     assert_equal(f.flags, HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY)
     assert_equal(f.stream_id, 0x1234567)
-    assert_equal(f.header_block_fragment, 'foobar')
+    assert_equal(f.headers, [('host', 'foo.bar')])
     assert_equal(f.exclusive, True)
     assert_equal(f.stream_dependency, 0x7654321)
     assert_equal(f.weight, 42)
 
-    f = Frame.from_bytes('00000f01280123456703076543212a666f6f626172000000'.decode('hex'))
+    f = Frame.from_bytes('00001001280123456703076543212a668594e75e31d9000000'.decode('hex'))
     assert isinstance(f, HeadersFrame)
-    assert_equal(f.length, 15)
+    assert_equal(f.length, 16)
     assert_equal(f.TYPE, HeadersFrame.TYPE)
     assert_equal(f.flags, HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY)
     assert_equal(f.stream_id, 0x1234567)
-    assert_equal(f.header_block_fragment, 'foobar')
+    assert_equal(f.headers, [('host', 'foo.bar')])
     assert_equal(f.exclusive, False)
     assert_equal(f.stream_dependency, 0x7654321)
     assert_equal(f.weight, 42)
 
+
 def test_headers_frame_human_readable():
-    f = HeadersFrame(14, HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY, 0x1234567, 'foobar', pad_length=3, exclusive=False, stream_dependency=0x7654321, weight=42)
+    f = HeadersFrame(
+        7,
+        HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY,
+        0x1234567,
+        headers=[],
+        pad_length=3,
+        exclusive=False,
+        stream_dependency=0x7654321,
+        weight=42)
     assert f.human_readable()
+
+    f = HeadersFrame(
+        14,
+        HeadersFrame.FLAG_PADDED | HeadersFrame.FLAG_PRIORITY,
+        0x1234567,
+        headers=[('host', 'foo.bar')],
+        pad_length=3,
+        exclusive=False,
+        stream_dependency=0x7654321,
+        weight=42)
+    assert f.human_readable()
+
 
 def test_priority_frame_to_bytes():
     f = PriorityFrame(5, Frame.FLAG_NO_FLAGS, 0x1234567, exclusive=True, stream_dependency=0x7654321, weight=42)
@@ -134,6 +193,7 @@ def test_priority_frame_to_bytes():
 
     f = PriorityFrame(5, Frame.FLAG_NO_FLAGS, 0x1234567, stream_dependency=0x0)
     tutils.raises(ValueError, f.to_bytes)
+
 
 def test_priority_frame_from_bytes():
     f = Frame.from_bytes('000005020001234567876543212a'.decode('hex'))
@@ -156,9 +216,11 @@ def test_priority_frame_from_bytes():
     assert_equal(f.stream_dependency, 0x7654321)
     assert_equal(f.weight, 21)
 
+
 def test_priority_frame_human_readable():
     f = PriorityFrame(5, Frame.FLAG_NO_FLAGS, 0x1234567, exclusive=False, stream_dependency=0x7654321, weight=21)
     assert f.human_readable()
+
 
 def test_rst_stream_frame_to_bytes():
     f = RstStreamFrame(4, Frame.FLAG_NO_FLAGS, 0x1234567, error_code=0x7654321)
@@ -166,6 +228,7 @@ def test_rst_stream_frame_to_bytes():
 
     f = RstStreamFrame(4, Frame.FLAG_NO_FLAGS, 0x0)
     tutils.raises(ValueError, f.to_bytes)
+
 
 def test_rst_stream_frame_from_bytes():
     f = Frame.from_bytes('00000403000123456707654321'.decode('hex'))
@@ -176,9 +239,11 @@ def test_rst_stream_frame_from_bytes():
     assert_equal(f.stream_id, 0x1234567)
     assert_equal(f.error_code, 0x07654321)
 
+
 def test_rst_stream_frame_human_readable():
     f = RstStreamFrame(4, Frame.FLAG_NO_FLAGS, 0x1234567, error_code=0x7654321)
     assert f.human_readable()
+
 
 def test_settings_frame_to_bytes():
     f = SettingsFrame(0, Frame.FLAG_NO_FLAGS, 0x0)
@@ -187,15 +252,25 @@ def test_settings_frame_to_bytes():
     f = SettingsFrame(0, SettingsFrame.FLAG_ACK, 0x0)
     assert_equal(f.to_bytes().encode('hex'), '000000040100000000')
 
-    f = SettingsFrame(6, SettingsFrame.FLAG_ACK, 0x0, settings={SettingsFrame.SETTINGS.SETTINGS_ENABLE_PUSH: 1})
+    f = SettingsFrame(
+        6,
+        SettingsFrame.FLAG_ACK, 0x0,
+        settings={
+            SettingsFrame.SETTINGS.SETTINGS_ENABLE_PUSH: 1})
     assert_equal(f.to_bytes().encode('hex'), '000006040100000000000200000001')
 
-    f = SettingsFrame(12, Frame.FLAG_NO_FLAGS, 0x0, settings={
-                      SettingsFrame.SETTINGS.SETTINGS_ENABLE_PUSH: 1, SettingsFrame.SETTINGS.SETTINGS_MAX_CONCURRENT_STREAMS: 0x12345678})
+    f = SettingsFrame(
+        12,
+        Frame.FLAG_NO_FLAGS,
+        0x0,
+        settings={
+            SettingsFrame.SETTINGS.SETTINGS_ENABLE_PUSH: 1,
+            SettingsFrame.SETTINGS.SETTINGS_MAX_CONCURRENT_STREAMS: 0x12345678})
     assert_equal(f.to_bytes().encode('hex'), '00000c040000000000000200000001000312345678')
 
     f = SettingsFrame(0, Frame.FLAG_NO_FLAGS, 0x1234567)
     tutils.raises(ValueError, f.to_bytes)
+
 
 def test_settings_frame_from_bytes():
     f = Frame.from_bytes('000000040000000000'.decode('hex'))
@@ -231,12 +306,20 @@ def test_settings_frame_from_bytes():
     assert_equal(f.settings[SettingsFrame.SETTINGS.SETTINGS_ENABLE_PUSH], 1)
     assert_equal(f.settings[SettingsFrame.SETTINGS.SETTINGS_MAX_CONCURRENT_STREAMS], 0x12345678)
 
+
 def test_settings_frame_human_readable():
     f = SettingsFrame(12, Frame.FLAG_NO_FLAGS, 0x0, settings={})
     assert f.human_readable()
 
-    f = SettingsFrame(12, Frame.FLAG_NO_FLAGS, 0x0, settings={SettingsFrame.SETTINGS.SETTINGS_ENABLE_PUSH: 1, SettingsFrame.SETTINGS.SETTINGS_MAX_CONCURRENT_STREAMS: 0x12345678})
+    f = SettingsFrame(
+        12,
+        Frame.FLAG_NO_FLAGS,
+        0x0,
+        settings={
+            SettingsFrame.SETTINGS.SETTINGS_ENABLE_PUSH: 1,
+            SettingsFrame.SETTINGS.SETTINGS_MAX_CONCURRENT_STREAMS: 0x12345678})
     assert f.human_readable()
+
 
 def test_push_promise_frame_to_bytes():
     f = PushPromiseFrame(10, Frame.FLAG_NO_FLAGS, 0x1234567, 0x7654321, 'foobar')
@@ -250,6 +333,7 @@ def test_push_promise_frame_to_bytes():
 
     f = PushPromiseFrame(4, Frame.FLAG_NO_FLAGS, 0x1234567, 0x0)
     tutils.raises(ValueError, f.to_bytes)
+
 
 def test_push_promise_frame_from_bytes():
     f = Frame.from_bytes('00000a05000123456707654321666f6f626172'.decode('hex'))
@@ -268,9 +352,11 @@ def test_push_promise_frame_from_bytes():
     assert_equal(f.stream_id, 0x1234567)
     assert_equal(f.header_block_fragment, 'foobar')
 
+
 def test_push_promise_frame_human_readable():
     f = PushPromiseFrame(14, HeadersFrame.FLAG_PADDED, 0x1234567, 0x7654321, 'foobar', pad_length=3)
     assert f.human_readable()
+
 
 def test_ping_frame_to_bytes():
     f = PingFrame(8, PingFrame.FLAG_ACK, 0x0, payload=b'foobar')
@@ -281,6 +367,7 @@ def test_ping_frame_to_bytes():
 
     f = PingFrame(8, Frame.FLAG_NO_FLAGS, 0x1234567)
     tutils.raises(ValueError, f.to_bytes)
+
 
 def test_ping_frame_from_bytes():
     f = Frame.from_bytes('000008060100000000666f6f6261720000'.decode('hex'))
@@ -299,9 +386,11 @@ def test_ping_frame_from_bytes():
     assert_equal(f.stream_id, 0x0)
     assert_equal(f.payload, b'foobarde')
 
+
 def test_ping_frame_human_readable():
     f = PingFrame(8, PingFrame.FLAG_ACK, 0x0, payload=b'foobar')
     assert f.human_readable()
+
 
 def test_goaway_frame_to_bytes():
     f = GoAwayFrame(8, Frame.FLAG_NO_FLAGS, 0x0, last_stream=0x1234567, error_code=0x87654321, data=b'')
@@ -312,6 +401,7 @@ def test_goaway_frame_to_bytes():
 
     f = GoAwayFrame(8, Frame.FLAG_NO_FLAGS, 0x1234567, last_stream=0x1234567, error_code=0x87654321)
     tutils.raises(ValueError, f.to_bytes)
+
 
 def test_goaway_frame_from_bytes():
     f = Frame.from_bytes('0000080700000000000123456787654321'.decode('hex'))
@@ -334,9 +424,11 @@ def test_goaway_frame_from_bytes():
     assert_equal(f.error_code, 0x87654321)
     assert_equal(f.data, b'foobar')
 
+
 def test_go_away_frame_human_readable():
     f = GoAwayFrame(14, Frame.FLAG_NO_FLAGS, 0x0, last_stream=0x1234567, error_code=0x87654321, data=b'foobar')
     assert f.human_readable()
+
 
 def test_window_update_frame_to_bytes():
     f = WindowUpdateFrame(4, Frame.FLAG_NO_FLAGS, 0x0, window_size_increment=0x1234567)
@@ -351,6 +443,7 @@ def test_window_update_frame_to_bytes():
     f = WindowUpdateFrame(4, Frame.FLAG_NO_FLAGS, 0x0, window_size_increment=0)
     tutils.raises(ValueError, f.to_bytes)
 
+
 def test_window_update_frame_from_bytes():
     f = Frame.from_bytes('00000408000000000001234567'.decode('hex'))
     assert isinstance(f, WindowUpdateFrame)
@@ -360,9 +453,11 @@ def test_window_update_frame_from_bytes():
     assert_equal(f.stream_id, 0x0)
     assert_equal(f.window_size_increment, 0x1234567)
 
+
 def test_window_update_frame_human_readable():
     f = WindowUpdateFrame(4, Frame.FLAG_NO_FLAGS, 0x1234567, window_size_increment=0x7654321)
     assert f.human_readable()
+
 
 def test_continuation_frame_to_bytes():
     f = ContinuationFrame(6, ContinuationFrame.FLAG_END_HEADERS, 0x1234567, 'foobar')
@@ -370,6 +465,7 @@ def test_continuation_frame_to_bytes():
 
     f = ContinuationFrame(6, ContinuationFrame.FLAG_END_HEADERS, 0x0, 'foobar')
     tutils.raises(ValueError, f.to_bytes)
+
 
 def test_continuation_frame_from_bytes():
     f = Frame.from_bytes('000006090401234567666f6f626172'.decode('hex'))
@@ -379,6 +475,7 @@ def test_continuation_frame_from_bytes():
     assert_equal(f.flags, ContinuationFrame.FLAG_END_HEADERS)
     assert_equal(f.stream_id, 0x1234567)
     assert_equal(f.header_block_fragment, 'foobar')
+
 
 def test_continuation_frame_human_readable():
     f = ContinuationFrame(6, ContinuationFrame.FLAG_END_HEADERS, 0x1234567, 'foobar')

--- a/test/test_tcp.py
+++ b/test/test_tcp.py
@@ -603,6 +603,7 @@ class TestAddress:
         assert a.use_ipv6
         b = tcp.Address("foo.com", True)
         assert not a == b
+        assert str(b) == str(tuple("foo.com"))
         c = tcp.Address("localhost", True)
         assert a == c
         assert not a != c

--- a/test/test_tcp.py
+++ b/test/test_tcp.py
@@ -4,11 +4,14 @@ import time
 import socket
 import random
 import os
-from netlib import tcp, certutils, test, certffi
 import threading
 import mock
-import tutils
+
 from OpenSSL import SSL
+import OpenSSL
+
+from netlib import tcp, certutils, test, certffi
+import tutils
 
 
 class EchoHandler(tcp.BaseHandler):
@@ -399,12 +402,14 @@ class TestALPN(test.ServerTestBase):
         alpn_select="h2"
     )
 
-    def test_alpn(self):
-        c = tcp.TCPClient(("127.0.0.1", self.port))
-        c.connect()
-        c.convert_to_ssl(alpn_protos=["h2"])
-        print "ALPN: %s" % c.get_alpn_proto_negotiated()
-        assert c.get_alpn_proto_negotiated() == "h2"
+    if OpenSSL._util.lib.Cryptography_HAS_ALPN:
+
+        def test_alpn(self):
+            c = tcp.TCPClient(("127.0.0.1", self.port))
+            c.connect()
+            c.convert_to_ssl(alpn_protos=["h2"])
+            print "ALPN: %s" % c.get_alpn_proto_negotiated()
+            assert c.get_alpn_proto_negotiated() == "h2"
 
 
 class TestSSLTimeOut(test.ServerTestBase):

--- a/test/test_tcp.py
+++ b/test/test_tcp.py
@@ -389,6 +389,24 @@ class TestTimeOut(test.ServerTestBase):
         tutils.raises(tcp.NetLibTimeout, c.rfile.read, 10)
 
 
+class TestALPN(test.ServerTestBase):
+    handler = HangHandler
+    ssl = dict(
+        cert=tutils.test_data.path("data/server.crt"),
+        key=tutils.test_data.path("data/server.key"),
+        request_client_cert=False,
+        v3_only=False,
+        alpn_select="h2"
+    )
+
+    def test_alpn(self):
+        c = tcp.TCPClient(("127.0.0.1", self.port))
+        c.connect()
+        c.convert_to_ssl(alpn_protos=["h2"])
+        print "ALPN: %s" % c.get_alpn_proto_negotiated()
+        assert c.get_alpn_proto_negotiated() == "h2"
+
+
 class TestSSLTimeOut(test.ServerTestBase):
     handler = HangHandler
     ssl = dict(


### PR DESCRIPTION
This PR improves the HTTP/2 code.

* use HPACK for header encoding and decoding
* add `human_readable` method for each Frame
  * for easy debugging and logging of individual frames
* add `from_file` method to Frame to parse a frame from a file-like object
* add ALPN support to TCP Connection
  * client: `alpn_protos` defines a list of application layer protocols: `[b'http1.1', b'h2']`
  * server: `alpn_select` defines which protocol should be selected `b'h2'`
  * since ALPN requires OpenSSL 1.0.2 - the relevant tests are NOT run on TravisCI
* add an example on how to use the new `H2Client`
  * this still needs tests