### PR TITLE
improve ALPN support on travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ MANIFEST
 .idea/
 __pycache__
 _cffi__*
+.eggs/
 netlib.egg-info/
 pathod/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,67 @@
 language: python
+
 sudo: false
+
 python:
   - "2.7"
   - pypy
-# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+
+matrix:
+  include:
+    - python: 2.7
+      env: OPENSSL=1.0.2
+      addons:
+        apt:
+          sources:
+            # Debian sid currently holds OpenSSL 1.0.2
+            # change this with future releases!
+            - debian-sid
+          packages:
+            - libssl-dev
+    - python: pypy
+      env: OPENSSL=1.0.2
+      addons:
+        apt:
+          sources:
+            # Debian sid currently holds OpenSSL 1.0.2
+            # change this with future releases!
+            - debian-sid
+          packages:
+            - libssl-dev
+
 install:
   - "pip install --src . -r requirements.txt"
-# command to run tests, e.g. python setup.py test
+
+before_script:
+  - "openssl version -a"
+
 script:
   - "nosetests --with-cov --cov-report term-missing"
   - "./check_coding_style.sh"
+
 after_success:
   - coveralls
+
 notifications:
   irc:
     channels:
       - "irc.oftc.net#mitmproxy"
     on_success: change
     on_failure: always
+
+# exclude cryptography from cache
+# it depends on libssl-dev version
+# which needs to be compiled specifically to each version
+before_cache:
+  - pip uninstall -y cryptography
+  - rm -rf /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/cryptography/
+  - rm -rf /home/travis/virtualenv/pypy-2.5.0/site-packages/cryptography/
+  - rm /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/pip/_vendor/requests/packages/urllib3/contrib/pyopenssl.py
+  - rm /home/travis/virtualenv/pypy-2.5.0/site-packages/pip/_vendor/requests/packages/urllib3/contrib/pyopenssl.py
+
 cache:
   directories:
-  - /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages
-  - /home/travis/virtualenv/python2.7.9/bin
-  - /home/travis/virtualenv/pypy-2.5.0/site-packages
-  - /home/travis/virtualenv/pypy-2.5.0/bin
+    - /home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages
+    - /home/travis/virtualenv/python2.7.9/bin
+    - /home/travis/virtualenv/pypy-2.5.0/site-packages
+    - /home/travis/virtualenv/pypy-2.5.0/bin

--- a/netlib/http2/protocol.py
+++ b/netlib/http2/protocol.py
@@ -61,7 +61,6 @@ class HTTP2Protocol(object):
         assert settings_ack_frame.flags & frame.Frame.FLAG_ACK
         assert len(settings_ack_frame.settings) == 0
 
-
     def next_stream_id(self):
         if self.current_stream_id is None:
             self.current_stream_id = 1
@@ -89,7 +88,10 @@ class HTTP2Protocol(object):
 
             self.http2_settings[setting] = value
 
-        self.send_frame(frame.SettingsFrame(state=self, flags=frame.Frame.FLAG_ACK))
+        self.send_frame(
+            frame.SettingsFrame(
+                state=self,
+                flags=frame.Frame.FLAG_ACK))
 
     def _create_headers(self, headers, stream_id, end_stream=True):
         # TODO: implement max frame size checks and sending in chunks

--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -6,6 +6,8 @@ import sys
 import threading
 import time
 import traceback
+
+import OpenSSL
 from OpenSSL import SSL
 
 from . import certutils
@@ -401,16 +403,17 @@ class _Connection(object):
         if log_ssl_key:
             context.set_info_callback(log_ssl_key)
 
-        # advertise application layer protocols
-        if alpn_protos is not None:
-            context.set_alpn_protos(alpn_protos)
+        if OpenSSL._util.lib.Cryptography_HAS_ALPN:
+            # advertise application layer protocols
+            if alpn_protos is not None:
+                context.set_alpn_protos(alpn_protos)
 
-        # select application layer protocol
-        if alpn_select is not None:
-            def alpn_select_f(conn, options):
-                return bytes(alpn_select)
+            # select application layer protocol
+            if alpn_select is not None:
+                def alpn_select_f(conn, options):
+                    return bytes(alpn_select)
 
-            context.set_alpn_select_callback(alpn_select_f)
+                context.set_alpn_select_callback(alpn_select_f)
 
         return context
 


### PR DESCRIPTION
* do NOT fail if ALPN support is missing, silently ignore ALPN-related settings
* test with OpenSSL 1.0.2 from Debian sid
* exclude `cryptography` from the caches - because it needs to be compiled against the correct OpenSSL version
* fix coding style - to get a completely green build
* Travis seems to create a `.eggs/` directory - just ignore it in git.

In the future it might be necessary to change the apt-repo for `libssl-dev` to get the correct version.