### PR TITLE
Fixing upstream certificate validation bugs

### DIFF
--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -422,7 +422,7 @@ class _Connection(object):
 
             context.set_verify(verify_options, verify_cert)
             if ca_path is None and ca_pemfile is None:
-                ca_path = certifi.where()
+                ca_pemfile = certifi.where()
             context.load_verify_locations(ca_pemfile, ca_path)
 
         # Workaround for

--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -518,6 +518,13 @@ class TCPClient(_Connection):
             self.connection.do_handshake()
         except SSL.Error as v:
             raise NetLibError("SSL handshake error: %s" % repr(v))
+
+        # Fix for pre v1.0 OpenSSL, which doesn't throw an exception on
+        # certificate validation failure
+        verification_mode = sslctx_kwargs.get('verify_options', None)
+        if self.ssl_verification_error is not None and verification_mode == SSL.VERIFY_PEER:
+            raise NetLibError("SSL handshake error: certificate verify failed")
+
         self.ssl_established = True
         self.cert = certutils.SSLCert(self.connection.get_peer_certificate())
         self.rfile.set_descriptor(self.connection)


### PR DESCRIPTION
Fixed two bugs:
- Default CA for server verification (certifi) was being incorrectly set resulting in incorrect validation errors and warnings
- When using an OpenSSL version prior to v1.0 certificate validation failures weren't correctly aborting the connection when the --verify-upstream-cert flag was used