### PR TITLE
[WIP] Protocol Refactoring for HTTP/2

### DIFF
--- a/netlib/http/http1/protocol.py
+++ b/netlib/http/http1/protocol.py
@@ -7,6 +7,7 @@ import urlparse
 import time
 
 from netlib import odict, utils, tcp, http
+from netlib.http import semantics
 from .. import status_codes
 from ..exceptions import *
 
@@ -15,7 +16,7 @@ class TCPHandler(object):
         self.rfile = rfile
         self.wfile = wfile
 
-class HTTP1Protocol(object):
+class HTTP1Protocol(semantics.ProtocolMixin):
 
     def __init__(self, tcp_handler=None, rfile=None, wfile=None):
         self.tcp_handler = tcp_handler or TCPHandler(rfile, wfile)
@@ -195,6 +196,32 @@ class HTTP1Protocol(object):
         )
 
 
+    def assemble_request(self, request):
+        assert isinstance(request, semantics.Request)
+
+        if request.body == semantics.CONTENT_MISSING:
+            raise http.HttpError(
+                502,
+                "Cannot assemble flow with CONTENT_MISSING"
+            )
+        first_line = self._assemble_request_first_line(request)
+        headers = self._assemble_request_headers(request)
+        return "%s\r\n%s\r\n%s" % (first_line, headers, request.body)
+
+
+    def assemble_response(self, response):
+        assert isinstance(response, semantics.Response)
+
+        if response.body == semantics.CONTENT_MISSING:
+            raise http.HttpError(
+                502,
+                "Cannot assemble flow with CONTENT_MISSING"
+            )
+        first_line = self._assemble_response_first_line(response)
+        headers = self._assemble_response_headers(response)
+        return "%s\r\n%s\r\n%s" % (first_line, headers, response.body)
+
+
     def read_headers(self):
         """
             Read a set of headers.
@@ -363,7 +390,6 @@ class HTTP1Protocol(object):
         return line
 
 
-
     def _read_chunked(self, limit, is_request):
         """
             Read a chunked HTTP body.
@@ -526,3 +552,74 @@ class HTTP1Protocol(object):
         except ValueError:
             return None
         return (proto, code, msg)
+
+
+    @classmethod
+    def _assemble_request_first_line(self, request):
+        if request.form_in == "relative":
+            request_line = '%s %s HTTP/%s.%s' % (
+                request.method,
+                request.path,
+                request.httpversion[0],
+                request.httpversion[1],
+            )
+        elif request.form_in == "authority":
+            request_line = '%s %s:%s HTTP/%s.%s' % (
+                request.method,
+                request.host,
+                request.port,
+                request.httpversion[0],
+                request.httpversion[1],
+            )
+        elif request.form_in == "absolute":
+            request_line = '%s %s://%s:%s%s HTTP/%s.%s' % (
+                request.method,
+                request.scheme,
+                request.host,
+                request.port,
+                request.path,
+                request.httpversion[0],
+                request.httpversion[1],
+            )
+        else:
+            raise http.HttpError(400, "Invalid request form")
+        return request_line
+
+    def _assemble_request_headers(self, request):
+        headers = request.headers.copy()
+        for k in request._headers_to_strip_off:
+            del headers[k]
+        if 'host' not in headers and request.scheme and request.host and request.port:
+            headers["Host"] = [utils.hostport(request.scheme,
+                                              request.host,
+                                              request.port)]
+
+        # If content is defined (i.e. not None or CONTENT_MISSING), we always
+        # add a content-length header.
+        if request.body or request.body == "":
+            headers["Content-Length"] = [str(len(request.body))]
+
+        return headers.format()
+
+
+    def _assemble_response_first_line(self, response):
+        return 'HTTP/%s.%s %s %s' % (
+            response.httpversion[0],
+            response.httpversion[1],
+            response.status_code,
+            response.msg,
+        )
+
+    def _assemble_response_headers(self, response, preserve_transfer_encoding=False):
+        headers = response.headers.copy()
+        for k in response._headers_to_strip_off:
+            del headers[k]
+        if not preserve_transfer_encoding:
+            del headers['Transfer-Encoding']
+
+        # If body is defined (i.e. not None or CONTENT_MISSING), we always
+        # add a content-length header.
+        if response.body or response.body == "":
+            headers["Content-Length"] = [str(len(response.body))]
+
+        return headers.format()

--- a/netlib/http/semantics.py
+++ b/netlib/http/semantics.py
@@ -7,6 +7,32 @@ import urlparse
 
 from .. import utils, odict
 
+CONTENT_MISSING = 0
+
+
+class ProtocolMixin(object):
+
+    def read_request(self):
+        raise NotImplemented
+
+    def read_response(self):
+        raise NotImplemented
+
+    def assemble(self, message):
+        if isinstance(message, Request):
+            return self.assemble_request(message)
+        elif isinstance(message, Response):
+            return self.assemble_response(message)
+        else:
+            raise ValueError("HTTP message not supported.")
+
+    def assemble_request(self, request):
+        raise NotImplemented
+
+    def assemble_response(self, response):
+        raise NotImplemented
+
+
 class Request(object):
 
     def __init__(
@@ -18,12 +44,14 @@ class Request(object):
         port,
         path,
         httpversion,
-        headers,
-        body,
+        headers=None,
+        body=None,
         timestamp_start=None,
         timestamp_end=None,
     ):
-        assert isinstance(headers, odict.ODictCaseless) or not headers
+        if not headers:
+            headers = odict.ODictCaseless()
+        assert isinstance(headers, odict.ODictCaseless)
 
         self.form_in = form_in
         self.method = method
@@ -36,6 +64,7 @@ class Request(object):
         self.body = body
         self.timestamp_start = timestamp_start
         self.timestamp_end = timestamp_end
+
 
     def __eq__(self, other):
         try:
@@ -80,14 +109,16 @@ class Response(object):
         self,
         httpversion,
         status_code,
-        msg,
-        headers,
-        body,
+        msg=None,
+        headers=None,
+        body=None,
         sslinfo=None,
         timestamp_start=None,
         timestamp_end=None,
     ):
-        assert isinstance(headers, odict.ODictCaseless) or not headers
+        if not headers:
+            headers = odict.ODictCaseless()
+        assert isinstance(headers, odict.ODictCaseless)
 
         self.httpversion = httpversion
         self.status_code = status_code
@@ -97,6 +128,7 @@ class Response(object):
         self.sslinfo = sslinfo
         self.timestamp_start = timestamp_start
         self.timestamp_end = timestamp_end
+
 
     def __eq__(self, other):
         try:

--- a/netlib/http/semantics.py
+++ b/netlib/http/semantics.py
@@ -20,7 +20,11 @@ class Request(object):
         httpversion,
         headers,
         body,
+        timestamp_start=None,
+        timestamp_end=None,
     ):
+        assert isinstance(headers, odict.ODictCaseless) or not headers
+
         self.form_in = form_in
         self.method = method
         self.scheme = scheme
@@ -30,16 +34,29 @@ class Request(object):
         self.httpversion = httpversion
         self.headers = headers
         self.body = body
+        self.timestamp_start = timestamp_start
+        self.timestamp_end = timestamp_end
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        try:
+            self_d = [self.__dict__[k] for k in self.__dict__ if k not in ('timestamp_start', 'timestamp_end')]
+            other_d = [other.__dict__[k] for k in other.__dict__ if k not in ('timestamp_start', 'timestamp_end')]
+            return self_d == other_d
+        except:
+            return False
 
     def __repr__(self):
         return "Request(%s - %s, %s)" % (self.method, self.host, self.path)
 
     @property
     def content(self):
+        # TODO: remove deprecated getter
         return self.body
+
+    @content.setter
+    def content(self, content):
+        # TODO: remove deprecated setter
+        self.body = content
 
 
 class EmptyRequest(Request):
@@ -67,23 +84,51 @@ class Response(object):
         headers,
         body,
         sslinfo=None,
+        timestamp_start=None,
+        timestamp_end=None,
     ):
+        assert isinstance(headers, odict.ODictCaseless) or not headers
+
         self.httpversion = httpversion
         self.status_code = status_code
         self.msg = msg
         self.headers = headers
         self.body = body
         self.sslinfo = sslinfo
+        self.timestamp_start = timestamp_start
+        self.timestamp_end = timestamp_end
 
     def __eq__(self, other):
-        return self.__dict__ == other.__dict__
+        try:
+            self_d = [self.__dict__[k] for k in self.__dict__ if k not in ('timestamp_start', 'timestamp_end')]
+            other_d = [other.__dict__[k] for k in other.__dict__ if k not in ('timestamp_start', 'timestamp_end')]
+            return self_d == other_d
+        except:
+            return False
 
     def __repr__(self):
         return "Response(%s - %s)" % (self.status_code, self.msg)
 
     @property
     def content(self):
+        # TODO: remove deprecated getter
         return self.body
+
+    @content.setter
+    def content(self, content):
+        # TODO: remove deprecated setter
+        self.body = content
+
+    @property
+    def code(self):
+        # TODO: remove deprecated getter
+        return self.status_code
+
+    @code.setter
+    def code(self, code):
+        # TODO: remove deprecated setter
+        self.status_code = code
+
 
 
 def is_valid_port(port):

--- a/netlib/odict.py
+++ b/netlib/odict.py
@@ -96,8 +96,11 @@ class ODict(object):
                 return True
         return False
 
-    def add(self, key, value):
-        self.lst.append([key, value])
+    def add(self, key, value, prepend=False):
+        if prepend:
+            self.lst.insert(0, [key, value])
+        else:
+            self.lst.append([key, value])
 
     def get(self, k, d=None):
         if k in self:

--- a/netlib/utils.py
+++ b/netlib/utils.py
@@ -129,3 +129,13 @@ class Data(object):
         if not os.path.exists(fullpath):
             raise ValueError("dataPath: %s does not exist." % fullpath)
         return fullpath
+
+
+def hostport(scheme, host, port):
+    """
+        Returns the host component, with a port specifcation if needed.
+    """
+    if (port, scheme) in [(80, "http"), (443, "https")]:
+        return host
+    else:
+        return "%s:%s" % (host, port)

--- a/test/http/http1/test_protocol.py
+++ b/test/http/http1/test_protocol.py
@@ -297,10 +297,10 @@ class TestReadResponseNoContentLength(tservers.ServerTestBase):
 
 
 def test_read_response():
-    def tst(data, method, limit, include_body=True):
+    def tst(data, method, body_size_limit, include_body=True):
         data = textwrap.dedent(data)
         return mock_protocol(data).read_response(
-            method, limit, include_body=include_body
+            method, body_size_limit, include_body=include_body
         )
 
     tutils.raises("server disconnect", tst, "", "GET", None)

--- a/test/http/http2/test_protocol.py
+++ b/test/http/http2/test_protocol.py
@@ -222,7 +222,7 @@ class TestAssembleRequest():
         bytes = http2.HTTP2Protocol(self.c).assemble_request(http.Request(
             '',
             'GET',
-            '',
+            'https',
             '',
             '',
             '/',
@@ -237,7 +237,7 @@ class TestAssembleRequest():
         bytes = http2.HTTP2Protocol(self.c).assemble_request(http.Request(
             '',
             'GET',
-            '',
+            'https',
             '',
             '',
             '/',
@@ -269,11 +269,12 @@ class TestReadResponse(tservers.ServerTestBase):
         c.connect()
         c.convert_to_ssl()
         protocol = http2.HTTP2Protocol(c)
+        protocol.connection_preface_performed = True
 
         resp = protocol.read_response()
 
         assert resp.httpversion == (2, 0)
-        assert resp.status_code == "200"
+        assert resp.status_code == 200
         assert resp.msg == ""
         assert resp.headers.lst == [[':status', '200'], ['etag', 'foobar']]
         assert resp.body == b'foobar'
@@ -294,12 +295,13 @@ class TestReadEmptyResponse(tservers.ServerTestBase):
         c.connect()
         c.convert_to_ssl()
         protocol = http2.HTTP2Protocol(c)
+        protocol.connection_preface_performed = True
 
         resp = protocol.read_response()
 
         assert resp.stream_id
         assert resp.httpversion == (2, 0)
-        assert resp.status_code == "200"
+        assert resp.status_code == 200
         assert resp.msg == ""
         assert resp.headers.lst == [[':status', '200'], ['etag', 'foobar']]
         assert resp.body == b''
@@ -322,6 +324,7 @@ class TestReadRequest(tservers.ServerTestBase):
         c.connect()
         c.convert_to_ssl()
         protocol = http2.HTTP2Protocol(c, is_server=True)
+        protocol.connection_preface_performed = True
 
         resp = protocol.read_request()
 

--- a/test/http/http2/test_protocol.py
+++ b/test/http/http2/test_protocol.py
@@ -253,7 +253,7 @@ class TestReadResponse(tservers.ServerTestBase):
 
         resp = protocol.read_response()
 
-        assert resp.httpversion == "HTTP/2"
+        assert resp.httpversion == (2, 0)
         assert resp.status_code == "200"
         assert resp.msg == ""
         assert resp.headers.lst == [[':status', '200'], ['etag', 'foobar']]
@@ -279,7 +279,7 @@ class TestReadEmptyResponse(tservers.ServerTestBase):
         resp = protocol.read_response()
 
         assert resp.stream_id
-        assert resp.httpversion == "HTTP/2"
+        assert resp.httpversion == (2, 0)
         assert resp.status_code == "200"
         assert resp.msg == ""
         assert resp.headers.lst == [[':status', '200'], ['etag', 'foobar']]


### PR DESCRIPTION
This PR changes the protocol architecture and adds a unified interface for HTTP/1 and HTTP/2.
Most new code comes from mitmproxy.

ToDo:
- [ ] add tests for HTTP semantics classes
- [ ] port tests for HTTP/1 request-response assembly
- [ ] add tests for HTTP/2 request-response assembly