### PR TITLE
[WIP] Improve Http Message Content Semantics

### DIFF
--- a/netlib/exceptions.py
+++ b/netlib/exceptions.py
@@ -12,6 +12,7 @@ class NetlibException(Exception):
     """
     Base class for all exceptions thrown by netlib.
     """
+
     def __init__(self, message=None):
         super(NetlibException, self).__init__(message)
 
@@ -53,4 +54,8 @@ class TlsException(NetlibException):
 
 
 class InvalidCertificateException(TlsException):
+    pass
+
+
+class CodecException(NetlibException):
     pass

--- a/netlib/http/http1/assemble.py
+++ b/netlib/http/http1/assemble.py
@@ -7,10 +7,10 @@ from .. import CONTENT_MISSING
 
 
 def assemble_request(request):
-    if request.content == CONTENT_MISSING:
+    if request.raw_content == CONTENT_MISSING:
         raise HttpException("Cannot assemble flow with CONTENT_MISSING")
     head = assemble_request_head(request)
-    body = b"".join(assemble_body(request.data.headers, [request.data.content]))
+    body = b"".join(assemble_body(request.data.headers, [request.data.raw_content]))
     return head + body
 
 
@@ -21,10 +21,10 @@ def assemble_request_head(request):
 
 
 def assemble_response(response):
-    if response.content == CONTENT_MISSING:
+    if response.raw_content == CONTENT_MISSING:
         raise HttpException("Cannot assemble flow with CONTENT_MISSING")
     head = assemble_response_head(response)
-    body = b"".join(assemble_body(response.data.headers, [response.data.content]))
+    body = b"".join(assemble_body(response.data.headers, [response.data.raw_content]))
     return head + body
 
 

--- a/netlib/http/http1/read.py
+++ b/netlib/http/http1/read.py
@@ -11,7 +11,7 @@ from .. import Request, Response, Headers
 def read_request(rfile, body_size_limit=None):
     request = read_request_head(rfile)
     expected_body_size = expected_http_body_size(request)
-    request.data.content = b"".join(read_body(rfile, expected_body_size, limit=body_size_limit))
+    request.data.raw_content = b"".join(read_body(rfile, expected_body_size, limit=body_size_limit))
     request.timestamp_end = time.time()
     return request
 
@@ -50,7 +50,7 @@ def read_request_head(rfile):
 def read_response(rfile, request, body_size_limit=None):
     response = read_response_head(rfile)
     expected_body_size = expected_http_body_size(request, response)
-    response.data.content = b"".join(read_body(rfile, expected_body_size, body_size_limit))
+    response.data.raw_content = b"".join(read_body(rfile, expected_body_size, body_size_limit))
     response.timestamp_end = time.time()
     return response
 

--- a/netlib/http/request.py
+++ b/netlib/http/request.py
@@ -14,11 +14,9 @@ from .message import Message, _native, _always_bytes, MessageData
 
 
 class RequestData(MessageData):
-    def __init__(self, first_line_format, method, scheme, host, port, path, http_version, headers=None, content=None,
-                 timestamp_start=None, timestamp_end=None):
-        if not headers:
-            headers = Headers()
-        assert isinstance(headers, Headers)
+    def __init__(self, first_line_format, method, scheme, host, port, path, http_version, headers=None,
+                 raw_content=None, timestamp_start=None, timestamp_end=None):
+        super(RequestData, self).__init__(headers, raw_content)
 
         self.first_line_format = first_line_format
         self.method = method
@@ -27,8 +25,6 @@ class RequestData(MessageData):
         self.port = port
         self.path = path
         self.http_version = http_version
-        self.headers = headers
-        self.content = content
         self.timestamp_start = timestamp_start
         self.timestamp_end = timestamp_end
 

--- a/netlib/http/response.py
+++ b/netlib/http/response.py
@@ -10,17 +10,13 @@ from ..odict import ODict
 
 
 class ResponseData(MessageData):
-    def __init__(self, http_version, status_code, reason=None, headers=None, content=None,
+    def __init__(self, http_version, status_code, reason=None, headers=None, raw_content=None,
                  timestamp_start=None, timestamp_end=None):
-        if not headers:
-            headers = Headers()
-        assert isinstance(headers, Headers)
+        super(ResponseData, self).__init__(headers, raw_content)
 
         self.http_version = http_version
         self.status_code = status_code
         self.reason = reason
-        self.headers = headers
-        self.content = content
         self.timestamp_start = timestamp_start
         self.timestamp_end = timestamp_end
 

--- a/netlib/tutils.py
+++ b/netlib/tutils.py
@@ -106,7 +106,7 @@ def treq(**kwargs):
         path=b"/path",
         http_version=b"HTTP/1.1",
         headers=Headers(header="qvalue"),
-        content=b"content"
+        raw_content=b"content"
     )
     default.update(kwargs)
     return Request(**default)
@@ -122,7 +122,7 @@ def tresp(**kwargs):
         status_code=200,
         reason=b"OK",
         headers=Headers(header_response="svalue"),
-        content=b"message",
+        raw_content=b"message",
         timestamp_start=time.time(),
         timestamp_end=time.time(),
     )

--- a/test/http/http1/test_assemble.py
+++ b/test/http/http1/test_assemble.py
@@ -20,7 +20,7 @@ def test_assemble_request():
     )
 
     with raises(HttpException):
-        assemble_request(treq(content=CONTENT_MISSING))
+        assemble_request(treq(raw_content=CONTENT_MISSING))
 
 
 def test_assemble_request_head():
@@ -40,7 +40,7 @@ def test_assemble_response():
     )
 
     with raises(HttpException):
-        assemble_response(tresp(content=CONTENT_MISSING))
+        assemble_response(tresp(raw_content=CONTENT_MISSING))
 
 
 def test_assemble_response_head():
@@ -76,7 +76,7 @@ def test_assemble_request_line():
 
 def test_assemble_request_headers():
     # https://github.com/mitmproxy/mitmproxy/issues/186
-    r = treq(content=b"")
+    r = treq(raw_content=b"")
     r.headers["Transfer-Encoding"] = "chunked"
     c = _assemble_request_headers(r.data)
     assert b"Transfer-Encoding" in c
@@ -95,7 +95,7 @@ def test_assemble_request_headers_host_header():
 
 def test_assemble_response_headers():
     # https://github.com/mitmproxy/mitmproxy/issues/186
-    r = tresp(content=b"")
+    r = tresp(raw_content=b"")
     r.headers["Transfer-Encoding"] = "chunked"
     c = _assemble_response_headers(r)
     assert b"Transfer-Encoding" in c

--- a/test/http/http1/test_read.py
+++ b/test/http/http1/test_read.py
@@ -299,7 +299,7 @@ class TestReadHeaders(object):
 
 
 def test_read_chunked():
-    req = treq(content=None)
+    req = treq(raw_content=None)
     req.headers["Transfer-Encoding"] = "chunked"
 
     data = b"1\r\na\r\n0\r\n"

--- a/test/http/test_message.py
+++ b/test/http/test_message.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, print_function, division
-
 from netlib.http import decoded, Headers
 from netlib.tutils import tresp, raises
 
@@ -43,7 +42,7 @@ class TestMessageData(object):
         assert data == same
         assert not data != same
 
-        other = tresp(content=b"foo").data
+        other = tresp(status_code=418).data
         assert not data == other
         assert data != other
 
@@ -51,7 +50,6 @@ class TestMessageData(object):
 
 
 class TestMessage(object):
-
     def test_init(self):
         resp = tresp()
         assert resp.data
@@ -71,14 +69,14 @@ class TestMessage(object):
     def test_content_length_update(self):
         resp = tresp()
         resp.content = b"foo"
-        assert resp.data.content == b"foo"
+        assert resp.data.raw_content == b"foo"
         assert resp.headers["content-length"] == "3"
         resp.content = b""
-        assert resp.data.content == b""
+        assert resp.data.raw_content == b""
         assert resp.headers["content-length"] == "0"
 
-    def test_content_basic(self):
-        _test_passthrough_attr(tresp(), "content")
+    def test_raw_content_basic(self):
+        _test_passthrough_attr(tresp(), "raw_content")
 
     def test_headers(self):
         _test_passthrough_attr(tresp(), "headers")
@@ -93,61 +91,74 @@ class TestMessage(object):
         _test_decoded_attr(tresp(), "http_version")
 
 
-class TestDecodedDecorator(object):
-
-    def test_simple(self):
+class TestMessageContent(object):
+    def test_encode_decode(self):
         r = tresp()
+
+        assert "content-encoding" not in r.headers
+        assert r.raw_content == b"message"
         assert r.content == b"message"
-        assert "content-encoding" not in r.headers
+
         assert r.encode("gzip")
 
         assert r.headers["content-encoding"]
-        assert r.content != b"message"
-        with decoded(r):
-            assert "content-encoding" not in r.headers
-            assert r.content == b"message"
-        assert r.headers["content-encoding"]
-        assert r.content != b"message"
+        assert r.raw_content != b"message"
+        assert r.content == b"message"
 
-    def test_modify(self):
+        assert r.decode()
+
+        assert "content-encoding" not in r.headers
+        assert r.raw_content == b"message"
+        assert r.content == b"message"
+
+    def test_modify_content(self):
         r = tresp()
-        assert "content-encoding" not in r.headers
-        assert r.encode("gzip")
-
-        with decoded(r):
-            r.content = b"foo"
-
-        assert r.content != b"foo"
-        r.decode()
-        assert r.content == b"foo"
+        r.encode("gzip")
+        assert r.content == b"message"
+        r.raw_content = b"\x1f\x8b\x08\x00\x9cPIV\x02\xffKLJ\x06\x00\xc2A$5\x03\x00\x00\x00"
+        assert r.content == b"abc"
+        assert r.decode()
+        assert r.raw_content == b"abc"
 
     def test_unknown_ce(self):
         r = tresp()
         r.headers["content-encoding"] = "zopfli"
-        r.content = b"foo"
-        with decoded(r):
-            assert r.headers["content-encoding"]
-            assert r.content == b"foo"
-        assert r.headers["content-encoding"]
+
+        r.raw_content = b"foo"
         assert r.content == b"foo"
+
+        r.content = b"bar"
+        assert r.raw_content == b"bar"
 
     def test_cannot_decode(self):
         r = tresp()
         assert r.encode("gzip")
-        r.content = b"foo"
-        with decoded(r):
-            assert r.headers["content-encoding"]
-            assert r.content == b"foo"
-        assert r.headers["content-encoding"]
-        assert r.content != b"foo"
-        r.decode()
+        r.raw_content = b"foo"
+
+        assert not r.decode()
+
+        assert r.headers["content-encoding"] == "gzip"
         assert r.content == b"foo"
 
     def test_cannot_encode(self):
         r = tresp()
-        assert r.encode("gzip")
-        with decoded(r):
-            r.content = None
-
+        assert not r.encode("invalid encoding")
         assert "content-encoding" not in r.headers
+        assert r.raw_content is b"message"
+
+    def test_text_simple(self):
+        r = tresp()
+        assert r.text == u"message"
+        r.text = u"foo"
+        assert r.raw_content == b"foo"
+
+    def test_text_binary(self):
+        r = tresp(raw_content=b"\x00\xFF")
+        assert r.text == u"\x00\udcff"
+        r.text = r.text
+        assert r.raw_content == b"\x00\xFF"
+
+    def test_no_content(self):
+        r = tresp(raw_content=None)
         assert r.content is None
+        assert r.text is None

--- a/test/http/test_request.py
+++ b/test/http/test_request.py
@@ -213,7 +213,7 @@ class TestRequestUtils(object):
         assert "gzip" in request.headers["Accept-Encoding"]
 
     def test_get_urlencoded_form(self):
-        request = treq(content="foobar")
+        request = treq(raw_content="foobar")
         assert request.urlencoded_form is None
 
         request.headers["Content-Type"] = "application/x-www-form-urlencoded"
@@ -226,7 +226,7 @@ class TestRequestUtils(object):
         assert request.content
 
     def test_get_multipart_form(self):
-        request = treq(content="foobar")
+        request = treq(raw_content="foobar")
         assert request.multipart_form is None
 
         request.headers["Content-Type"] = "multipart/form-data"

--- a/test/test_encoding.py
+++ b/test/test_encoding.py
@@ -1,11 +1,14 @@
 from netlib import encoding
+from netlib.tutils import raises
 
 
 def test_identity():
     assert b"string" == encoding.decode("identity", b"string")
     assert b"string" == encoding.encode("identity", b"string")
-    assert not encoding.encode("nonexistent", b"string")
-    assert not encoding.decode("nonexistent encoding", b"string")
+    with raises(encoding.CodecException):
+        assert not encoding.encode("nonexistent", b"string")
+    with raises(encoding.CodecException):
+        assert not encoding.decode("nonexistent encoding", b"string")
 
 
 def test_gzip():
@@ -16,7 +19,8 @@ def test_gzip():
             b"string"
         )
     )
-    assert encoding.decode("gzip", b"bogus") is None
+    with raises(encoding.CodecException):
+        encoding.decode("gzip", b"bogus")
 
 
 def test_deflate():
@@ -34,4 +38,5 @@ def test_deflate():
             b"string"
         )[2:-4]
     )
-    assert encoding.decode("deflate", b"bogus") is None
+    with raises(encoding.CodecException):
+        encoding.decode("deflate", b"bogus")


### PR DESCRIPTION
:warning:  This is WIP - I did not adjust the tests yet.

--------------

This commit improves the semantics of request and response contents.
We now have:

  - `message.raw_content`: The unmodified, raw content as seen on the wire
  - `message.content`: The HTTP Content-Type-decoded content. That is, gzip
    or deflate compression are removed.
  - `message.text`: The HTTP Content-Type-decoded and charset-decoded
    content. This also takes into account the text encoding and returns a
    unicode string.

Both `.content` and `.text` are built in a way that they shall not fail under any circumstances. If there is an invalid HTTP Content-Type, accessing `.content` will return the verbatim `.raw_content`. For the text encoding, we first try the provided charset and then immediately fall back to surrogate-escaped utf8. Using chardet would be an alternative, but chardet is terribly slow in some cases (https://github.com/kennethreitz/requests/issues/2359). While `surrogateescape` may cause issues at other places (http://lucumr.pocoo.org/2013/7/2/the-updated-guide-to-unicode/), it nicely preserves "everything weird" if we apply mitmproxy replacements - this property probably justifies keeping it.

Thoughts?