### PR TITLE
Allow empty HTTP header value.

### DIFF
--- a/netlib/http/http1/read.py
+++ b/netlib/http/http1/read.py
@@ -321,7 +321,7 @@ def _read_headers(rfile):
             try:
                 name, value = line.split(b":", 1)
                 value = value.strip()
-                if not name or not value:
+                if not name:
                     raise ValueError()
                 ret.append([name, value])
             except ValueError:

--- a/test/http/http1/test_read.py
+++ b/test/http/http1/test_read.py
@@ -300,10 +300,7 @@ class TestReadHeaders(object):
     def test_read_empty_value(self):
         data = b"bar:"
         headers = self._read(data)
-        # XXX. WIP. break test
-        # assert headers.fields == [[b"bar", b""]]
-        with raises(HttpSyntaxException):
-            self._read(data)
+        assert headers.fields == [[b"bar", b""]]
 
 def test_read_chunked():
     req = treq(content=None)

--- a/test/http/http1/test_read.py
+++ b/test/http/http1/test_read.py
@@ -297,6 +297,13 @@ class TestReadHeaders(object):
         with raises(HttpSyntaxException):
             self._read(data)
 
+    def test_read_empty_value(self):
+        data = b"bar:"
+        headers = self._read(data)
+        # XXX. WIP. break test
+        # assert headers.fields == [[b"bar", b""]]
+        with raises(HttpSyntaxException):
+            self._read(data)
 
 def test_read_chunked():
     req = treq(content=None)


### PR DESCRIPTION
Fix to ignore empty header value.

According to Augmented BNF in the following RFCs

http://tools.ietf.org/html/rfc5234#section-3.6

http://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.1

        field-value    = *( field-content | LWS )

http://tools.ietf.org/html/rfc7230#section-3.2

        field-value    = *( field-content / obs-fold )

... the HTTP message header `field-value` is allowed to be empty.
