### PR TITLE
a little fix while installing under python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ deps = {
 }
 if sys.version_info < (3, 0):
     deps.add("ipaddress~=1.0.15")
+    deps = set(map(lambda x: x.replace('~', '>'), deps))
 
 setup(
     name="netlib",


### PR DESCRIPTION
Hello! I've had a need to install netlib from git reposetory for py27.... I couldn't do it because:
$ sudo python setup.py build
error in netlib setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers

After little analize I've understood that in py27 requirements like "pyasn1~=0.1.9" are wrong and instead of them should be "pyasn1>=0.1.9" so I've fixed it and installed
