### PR TITLE
Fix Reader.peek() on Python 3

### DIFF
--- a/netlib/tcp.py
+++ b/netlib/tcp.py
@@ -272,7 +272,7 @@ class Reader(_FileLike):
         Raises:
             TcpException if there was an error with the socket
             TlsException if there was an error with pyOpenSSL.
-            NotImplementedError if the underlying file object is not a (pyOpenSSL) socket
+            NotImplementedError if the underlying file object is not a [pyOpenSSL] socket
         """
         if isinstance(self.o, socket_fileobject):
             try:

--- a/test/test_tcp.py
+++ b/test/test_tcp.py
@@ -723,7 +723,7 @@ class TestPeek(tservers.ServerTestBase):
         c.wfile.write(testval)
         c.wfile.flush()
 
-        assert c.rfile.peek(4) == "peek"[:4]
+        assert c.rfile.peek(4) == b"peek"[:4]
         assert c.rfile.peek(6) == testval
 
 

--- a/test/test_tcp.py
+++ b/test/test_tcp.py
@@ -713,6 +713,20 @@ class TestFileLike:
         tutils.raises(TcpReadIncomplete, s.safe_read, 10)
 
 
+class TestPeek(tservers.ServerTestBase):
+    handler = EchoHandler
+
+    def test_peek(self):
+        testval = b"peek!\n"
+        c = tcp.TCPClient(("127.0.0.1", self.port))
+        c.connect()
+        c.wfile.write(testval)
+        c.wfile.flush()
+
+        assert c.rfile.peek(4) == "peek"[:4]
+        assert c.rfile.peek(6) == testval
+
+
 class TestAddress:
 
     def test_simple(self):


### PR DESCRIPTION
This PR fixes `Reader.peek()` on Python 3. The whole thing is tricker that it should be, mainly because `BufferedReader.peek()` has awful semantics:

```python
>>> import socket
>>> a, b = socket.socketpair()
>>> a.send(b"WTF")
3
>>> bf = b.makefile("rb")
>>> bf.peek(1)
b'WTF'
>>> a.send(b"FOO")
3
>>> bf.peek(1)
b'WTF'
>>> bf.peek(4)
b'WTF'  # Where is my fourth byte? :-(
```