### PR TITLE
http1: Set content None if the body doesn't exist

### DIFF
--- a/netlib/http/http1/assemble.py
+++ b/netlib/http/http1/assemble.py
@@ -10,8 +10,13 @@ def assemble_request(request):
     if request.content == CONTENT_MISSING:
         raise HttpException("Cannot assemble flow with CONTENT_MISSING")
     head = assemble_request_head(request)
-    body = b"".join(assemble_body(request.data.headers, [request.data.content]))
-    return head + body
+    if request.data.content is None:
+        return head
+    else:
+        body = b"".join(
+            assemble_body(request.data.headers,
+                          [request.data.content]))
+        return head + body
 
 
 def assemble_request_head(request):

--- a/netlib/http/message.py
+++ b/netlib/http/message.py
@@ -95,6 +95,9 @@ class Message(utils.Serializable):
         if isinstance(content, bytes):
             self.headers["content-length"] = str(len(content))
 
+    def expect_content(self):
+        raise NotImplementedError()
+
     @property
     def http_version(self):
         """

--- a/netlib/http/request.py
+++ b/netlib/http/request.py
@@ -50,6 +50,20 @@ class Request(Message):
             self.method, hostport, path
         )
 
+    def expect_content(self):
+        """
+        A boolean indicating whether a body is expected
+        """
+
+        # Determine to expect a boddy according to
+        # http://tools.ietf.org/html/rfc7230#section-3.3
+        if self.headers.get("expect", "").lower() == "100-continue":
+            return False
+        if not "content-length" in self.headers:
+            return False
+
+        return True
+
     @property
     def first_line_format(self):
         """

--- a/netlib/http/response.py
+++ b/netlib/http/response.py
@@ -46,6 +46,24 @@ class Response(Message):
             details=details
         )
 
+    def expect_content(self, request):
+        """
+        A boolean indicating whether a body is expected
+        """
+
+        # Determine to expect a boddy according to
+        # http://tools.ietf.org/html/rfc7230#section-3.3
+        if request.method.upper() == "HEAD":
+            return False
+        if 100 <= self.status_code <= 199:
+            return False
+        if self.status_code == 200 and request.method.upper() == "CONNECT":
+            return False
+        if self.status_code in (204, 304):
+            return False
+
+        return True
+
     @property
     def status_code(self):
         """


### PR DESCRIPTION
http1: Set content `None` if the body doesn't exist
Setting content `None` prevents from updating `Content-Length` in the header.
That allows to set proper `Content-Length` without content (e.g. `HEAD` method)

http1: Add `expect_http_body`
http1: Allow `None` for content

mitmproxy and pathod have problems with `None` content although mitmproxy says it can be `None`. (https://github.com/mitmproxy/mitmproxy/commit/89f22f735944989912a7a0394dd7e80d420cb0f3#diff-b0cf6bd2149496bffc04ec8cb1fbdd29R191) Those projects also need changes to adapt to this change.
mitmproxy: akihikodaki/mitmproxy@6892a08813b61b3dd40ba4a648fbe3f4e2c6fd0a
pathod: akihikodaki/pathod@7ad91146d978ea53976cd65d04249f94569120d0